### PR TITLE
firewall log rotation: add missingok directive to avoid error mail

### DIFF
--- a/root/etc/logrotate.d/firewall
+++ b/root/etc/logrotate.d/firewall
@@ -1,4 +1,5 @@
 /var/log/firewall.log {
     copytruncate
     compress
+    missingok
 }


### PR DESCRIPTION
**Issue found on v7.**
root got an email with the following content:
/etc/cron.daily/logrotate:
error: stat of /var/log/firewall.log failed: No such file or directory

The firewall.log file was really missing.
