### PR TITLE
Force all traffic through NFQ, if nfqueue is enabled

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/policy/20policy
+++ b/root/etc/e-smith/templates/etc/shorewall/policy/20policy
@@ -33,8 +33,19 @@
     foreach my $z (keys %zones) {
         $OUT .= "$z\t\tnet\t\t$action\n";
     }
+
+    if ($nfqueue eq 'enabled') {
+        $OUT .= "\n# firewall can always connect outside (via NFQ)\n";
+        $OUT .= "\$FW\tnet\tACCEPT:NFQBY\n";
+
+        $OUT .="# Traffic from firewall to local network is always allowed (via NFQ)\n";
+        $OUT .= "\$FW\tloc\tACCEPT:NFQBY\n";
+    } else {
+        $OUT .= "\n# firewall can always connect outside\n";
+        $OUT .= "\$FW\tnet\tACCEPT\n";
+
+        $OUT .="# Traffic from firewall to local network is always allowed\n";
+        $OUT .= "\$FW\tloc\tACCEPT\n";
+    }
+
 }
-
-# firewall can always connect outside
-$FW	net	ACCEPT
-

--- a/root/etc/e-smith/templates/etc/shorewall/policy/40policy_static
+++ b/root/etc/e-smith/templates/etc/shorewall/policy/40policy_static
@@ -4,9 +4,6 @@
 
 loc		$FW		REJECT		info
 
-# Traffic from firewall to local network is always allowed
-$FW		loc		ACCEPT
-
 # Drop traffic from external interface to firewall and local network
 net		$FW		DROP		info
 net		loc		DROP		info

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base20established
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base20established
@@ -16,12 +16,15 @@
         my $ndb = esmith::NetworksDB->open_ro();
         if ($ndb->blue) {
             $OUT .= "NFQBY\tblue\tnet\n";
+            $OUT .= "NFQBY\tnet\tblue\n";
         }
         if ($ndb->orange) {
             $OUT .= "NFQBY\torang\tnet\n";
+            $OUT .= "NFQBY\tnet\torang\n";
         }
         if ($ndb->blue && $ndb->orange) {
             $OUT .= "NFQBY\tblue\torang\n";
+            $OUT .= "NFQBY\torang\tblue\n";
         }
     }
 }

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base50related
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base50related
@@ -16,12 +16,15 @@
         my $ndb = esmith::NetworksDB->open_ro();
         if ($ndb->blue) {
             $OUT .= "NFQBY\tblue\tnet\n";
+            $OUT .= "NFQBY\tnet\tblue\n";
         }
         if ($ndb->orange) {
             $OUT .= "NFQBY\torang\tnet\n";
+            $OUT .= "NFQBY\tnet\torang\n";
         }
         if ($ndb->blue && $ndb->orange) {
             $OUT .= "NFQBY\tblue\torang\n";
+            $OUT .= "NFQBY\torang\tblue\n";
         }
     }
 }

--- a/root/etc/e-smith/templates/etc/shorewall/rules/20ping
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/20ping
@@ -1,5 +1,11 @@
 {
     my $extping = $firewall{'ExternalPing'} || 'enabled';
+    my $nfq = $firewall{'nfqueue'} || 'disabled';
+    my $action = 'ACCEPT';
+    if ($nfq eq 'enabled') {
+        $action = 'NFQBY';
+    }
+
     if ($extping eq 'disabled') {
 $OUT = <<EOF
 #
@@ -12,13 +18,16 @@ $OUT = <<EOF
 #
 # Accept Ping from the "bad" net zone.
 #
-Ping/ACCEPT   net             \$FW
+Ping/$action   net             \$FW
 EOF
     }
-}
+
+$OUT = <<EOF
 #
 #  Make ping work bi-directionally between the dmz, net, Firewall and local zone
 #  (assumes that the loc-> net policy is ACCEPT).
 #
-Ping/ACCEPT     loc            $FW
+Ping/$action    loc            \$FW
+EOF
 
+}

--- a/root/etc/e-smith/templates/etc/shorewall/rules/30dns
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/30dns
@@ -1,4 +1,12 @@
 #
 #       Accept DNS connections from the firewall to the Internet
 #
-DNS/ACCEPT      $FW             net
+{
+    my $nfq = $firewall{'nfqueue'} || 'disabled';
+    my $action = 'ACCEPT';
+    if ($nfq eq 'enabled') {
+        $action = 'NFQBY';
+    }
+
+    $OUT .= "DNS/$action\t\$FW\tnet";
+}

--- a/root/etc/e-smith/templates/etc/shorewall/rules/60rules
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/60rules
@@ -6,6 +6,7 @@
 
     my $db = esmith::ConfigDB->open_ro("fwrules") || die "Can't open portforward database: $!\n";
     my $fw = new NethServer::Firewall();
+    my $nfq = $firewall{'nfqueue'} || 'disabled';
     foreach my $rule ( $fw->getRules() ) {
         my $status = $rule->prop("status") || "disabled";
         next unless ($status eq 'enabled');
@@ -14,6 +15,10 @@
         my $dst = $rule->prop("Dst") || next;
         my $action= $rule->prop("Action") || next;
         $action = uc($action);
+
+        if ($nfq eq 'enabled' && $action eq 'ACCEPT') {
+            $action = "NFQBY";
+        }
         my $service = $rule->prop("Service") || '';
         my $log = $rule->prop('Log') || "";
         # skip ndpi rules if ndpi is not enabled

--- a/root/etc/e-smith/templates/etc/shorewall/rules/70services
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/70services
@@ -24,13 +24,18 @@
         my $type = shift;
         my $port = shift;
         my $zones = shift;
+        my $nfq = $firewall{'nfqueue'} || 'disabled';
+        my $action = 'ACCEPT';
+        if ($nfq eq 'enabled') {
+            $action = 'NFQBY';
+        }
         $OUT.="?COMMENT $name \n";
         foreach (@$zones) {
             $_ =~ s/^green$/loc/;
             $_ =~ s/^red$/net/;
             $_ = substr($_, 0, 5);
             if ($_ eq 'net' || $_ eq 'loc' || $fw->isZone($_)) {
-                $OUT.="ACCEPT\t$_\t\$FW\t$type\t$port\n";
+                $OUT.="$action\t$_\t\$FW\t$type\t$port\n";
             }
         }
 
@@ -41,17 +46,6 @@
     use esmith::ConfigDB;
     our $fw = NethServer::Firewall->new();
     my $confDb = esmith::ConfigDB->open();
-    my $accept = 'ACCEPT';
-    my $nfqueue = $firewall{'nfqueue'} || 'disabled';
-    if ($nfqueue eq 'enabled') {
-        $accept = 'NFQBY';
-        # SSH and HTTPD-ADMIN exeception: do not filter ssh from local network
-        $OUT.="#\n#\tAllow administration from local network\n#\n";
-        $OUT .= "?COMMENT always accept sshd from loc\n";
-        $OUT.="ACCEPT\tloc\t\$FW\ttcp\t".$sshd{'TCPPort'}."\n";
-        $OUT .= "?COMMENT always accept httpd-admin from loc\n";
-        $OUT.="ACCEPT\tloc\t\$FW\ttcp\t".${'httpd-admin'}{'TCPPort'}."\n";
-    }
 
     foreach my $serviceRecord ($confDb->get_all_by_prop('type' => 'service')) {
         my $access = $serviceRecord->prop('access') || 'none';


### PR DESCRIPTION
NethServer/dev#5104

When NFQ is enabled, an ACCEPT rule with logging enabled raises this Shorewall warning:

> Checking /etc/shorewall/action.NFQBY for chain %NFQBY...
>    WARNING: Log Prefix shortened to "Shorewall:NFQBY:IPTABLES(NFQ " /etc/shorewall/action.NFQBY (line 2)
>       from /etc/shorewall/rules (line 111)

We can avoid the warnings following this steps:
- in `shorewall.conf `change `LOGFORMAT` to `"FW:%s:%s:"`
- in `/etc/rsyslog.d/shorewall.conf` change the matching regexp