### PR TITLE
Traffic shaping: refactor rule order

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/20ndpi
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/20ndpi
@@ -1,5 +1,6 @@
 #
-# 80ndpi
+# 20ndpi
+# All nDPI traffic is marked in forward chain
 #
 {
    use NethServer::Database::Ndpi;

--- a/root/etc/e-smith/templates/etc/shorewall/mangle/40priorities
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/40priorities
@@ -1,45 +1,37 @@
 #
-# 40providers
+# 40priorities
+# All priority rules are marked inside the post chain.
+# If FW is the source, rules are moved to output chain.
 #
 {
     use NethServer::Firewall;
     use esmith::NetworksDB;
 
-    my $db = esmith::ConfigDB->open_ro("tc") || die "Can't open tc database: $!\n";
-    my $ndb = esmith::NetworksDB->open_ro() || die "Can't open networks database: $!\n";
     my $fw = new NethServer::Firewall();
+    my $ndb = esmith::NetworksDB->open_ro();
     our @providers = $fw->getProviders();
 
-    sub getProvider
-    {
-        my $needle = shift;
-
-        foreach my $p (@providers) {
-            if ($p->{'name'} eq $needle) {
-                return $p;
-            }
-        }   
-        return undef;
-    }
-
-    foreach my $rule ( $fw->getTcRules() ) {
+    foreach my $rule ( reverse($fw->getTcRules()) ) {
         my $src = $rule->prop("Src") || next;
         my $dst = $rule->prop("Dst") || next;
         my $status = $rule->prop("status") || 'disabled';
         next if ($status eq 'disabled');
 
-        my $provider = $rule->prop("Action") || next;
+        my $mask = '';
+        my $action = $rule->prop("Action") || next;
+        if ($action =~ /^priority;(.*)/) {
+            # map low to 3 (low), map high to 2 (medium)
+            # 1 (high) is reserved for system use
+            $mask = (lc($1) eq 'low') ? "0x3/0xff": "0x2/0xff"; 
+        } else {
+            # skip non-priority rules
+            next;
+        }
         my $service = $rule->prop("Service") || '';
         my $time = $fw->getTime($rule->prop("Time") || '');
 
         # skip ndpi rules if ndpi is not enabled
         next if ($fw->isNdpiService($service) && ! $fw->isNdpiEnabled());
-
-
-        # retrieve provider object
-        my ($type, $provider_key) = split(';', $provider);
-        my $p = getProvider($provider_key);
-        my $mask = $p->{'mask'} || next;
 
         my @src_addr;
         if ($src =~ /role;(.*)/) { # src is an interface
@@ -69,19 +61,23 @@
             $dst_addr = $fw->getAddress($dst, 1);
         }
 
+        my $description = $rule->prop('Description') || "RULE#" . $rule->key . " $service";
         foreach(@src_addr) {
 
+            my $chain = ':T';
+            if ( $_ eq '$FW') {
+                $chain = '';
+            }
             my $params = {
-                'action' => "MARK($mask)",
+                'action' => "MARK($mask)$chain",
                 'source' => $_,
                 'dest' => $dst_addr,
-                'comment' => "RULE#" . $rule->key . " " . ($rule->prop('Description') || ''),
+                'comment' => $description,
                 'time' => $time,
                 'service' => $service
             };
 
             $OUT .= $fw->outMangleRule($params);
         }
-
     }
 }

--- a/root/etc/e-smith/templates/etc/shorewall/mangle/60providers
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/60providers
@@ -1,34 +1,45 @@
 #
-# 20priorities
+# 60providers
 #
 {
     use NethServer::Firewall;
     use esmith::NetworksDB;
 
+    my $db = esmith::ConfigDB->open_ro("tc") || die "Can't open tc database: $!\n";
+    my $ndb = esmith::NetworksDB->open_ro() || die "Can't open networks database: $!\n";
     my $fw = new NethServer::Firewall();
     our @providers = $fw->getProviders();
 
-    foreach my $rule ( reverse($fw->getTcRules()) ) {
+    sub getProvider
+    {
+        my $needle = shift;
+
+        foreach my $p (@providers) {
+            if ($p->{'name'} eq $needle) {
+                return $p;
+            }
+        }   
+        return undef;
+    }
+
+    foreach my $rule ( $fw->getTcRules() ) {
         my $src = $rule->prop("Src") || next;
         my $dst = $rule->prop("Dst") || next;
         my $status = $rule->prop("status") || 'disabled';
         next if ($status eq 'disabled');
 
-        my $mask = '';
-        my $action = $rule->prop("Action") || next;
-        if ($action =~ /^priority;(.*)/) {
-            # map low to 3 (low), map high to 2 (medium)
-            # 1 (high) is reserved for system use
-            $mask = (lc($1) eq 'low') ? "0x3/0xff": "0x2/0xff"; 
-        } else {
-            # skip non-priority rules
-            next;
-        }
+        my $provider = $rule->prop("Action") || next;
         my $service = $rule->prop("Service") || '';
         my $time = $fw->getTime($rule->prop("Time") || '');
 
         # skip ndpi rules if ndpi is not enabled
         next if ($fw->isNdpiService($service) && ! $fw->isNdpiEnabled());
+
+
+        # retrieve provider object
+        my ($type, $provider_key) = split(';', $provider);
+        my $p = getProvider($provider_key);
+        my $mask = $p->{'mask'} || next;
 
         my @src_addr;
         if ($src =~ /role;(.*)/) { # src is an interface
@@ -58,19 +69,19 @@
             $dst_addr = $fw->getAddress($dst, 1);
         }
 
-        my $description = $rule->prop('Description') || "RULE#" . $rule->key . " $service";
         foreach(@src_addr) {
 
             my $params = {
                 'action' => "MARK($mask)",
                 'source' => $_,
                 'dest' => $dst_addr,
-                'comment' => $description,
+                'comment' => "RULE#" . $rule->key . " " . ($rule->prop('Description') || ''),
                 'time' => $time,
                 'service' => $service
             };
 
             $OUT .= $fw->outMangleRule($params);
         }
+
     }
 }


### PR DESCRIPTION
Assumptions and limitations

1. All nDPI traffic is marked in forward chain

2. Priority rules are in post chain and can use nDPI markers
    If a priority rule uses a role (interface) as source, the rule can't be added to postrouting chain since the packet is already natted: Shorewall will move the rule on top of forwarding chain

3. nDPI rules can't block the http/https traffic if web proxy is enabled in transparent mode

4. All nDPI markers are read from /proc/net/xt_ndpi/proto and shifted by 8 bits

5. Divert rules can't be used with nDPI, because an established TCP connection can't be moved between providers


NethServer/dev#5113