### PR TITLE
post-restore: move last actions to index 98

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -183,11 +183,11 @@ event_actions('static-routes-save', qw(
 
 event_actions('post-restore-config', qw(
     nethserver-firewall-base-disable 01
-    nethserver-firewall-base-condenable 99
+    nethserver-firewall-base-condenable 98
 ));
 
 event_actions('post-restore-data', qw(
-    nethserver-firewall-base-enable 99
+    nethserver-firewall-base-enable 98
 ));
 
 validator_actions('fwrule-modify', qw(


### PR DESCRIPTION
Index 99 is reserved for nethserver-backup-{config,data}
packages to close the restore transanction.

NethServer/dev#5343