### PR TITLE
Mask shorewall unit during ns6upgrade

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-firewall-base-disable
+++ b/root/etc/e-smith/events/actions/nethserver-firewall-base-disable
@@ -20,11 +20,6 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-status=$(/sbin/e-smith/config getprop shorewall status)
-
-if [[ "${status}" == "enabled" ]]; then
-    echo "[NOTICE] forcibly disable shorewall service"
-    /sbin/e-smith/config setprop shorewall status disabled
-    systemctl stop shorewall || :
-fi
-
+echo "[NOTICE] forcibly stop and mask shorewall service"
+systemctl stop shorewall
+systemctl --runtime mask shorewall

--- a/root/etc/e-smith/events/actions/nethserver-firewall-base-enable
+++ b/root/etc/e-smith/events/actions/nethserver-firewall-base-enable
@@ -22,9 +22,10 @@
 
 status=$(/sbin/e-smith/config getprop shorewall status)
 
-if [[ "${status}" == "disabled" ]]; then
-    echo "[NOTICE] forcibly enable shorewall service"
-    /sbin/e-smith/config setprop shorewall status enabled
+echo "[NOTICE] forcibly unmask shorewall service"
+systemctl --runtime unmask shorewall
+
+if [[ "${status}" == "enabled" ]]; then
     systemctl start shorewall || :
 fi
 

--- a/root/etc/e-smith/events/actions/nethserver-shorewall-restart
+++ b/root/etc/e-smith/events/actions/nethserver-shorewall-restart
@@ -45,6 +45,10 @@ if ( -f "/var/run/.nethserver-fixnetwork" ) {
     }
 }
 
+if( $shs->is_masked() ) {
+    exit(0);
+}
+
 # Fix for Shorewall 5
 if ( -f '/etc/shorewall/tcrules' ) {
     unlink '/etc/shorewall/tcrules';


### PR DESCRIPTION
Add support for masked unit to nethserver-shorewall-restart action

Unit are masked with symlinks under ``/run``. The masked state is lost after reboot. This solution does not alter the DB.

NethServer/dev#5343