### PR TITLE
pppoe: change connect_timeout to 0

### DIFF
--- a/root/etc/e-smith/events/actions/interface-config-write-pppoe
+++ b/root/etc/e-smith/events/actions/interface-config-write-pppoe
@@ -39,7 +39,7 @@ my %defaults = (qw(
     bootproto dialup
     clampmss 1412
     connect_poll 6
-    connect_timeout 60
+    connect_timeout 0
     defroute yes
     demand no
     device ppp0


### PR DESCRIPTION
This makes sure that the machine keeps trying
to connect forever after pppoe-start is called

NethServer/dev#5358