### PR TITLE
sNAT UI: always use 'host' object type

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Nat.php
+++ b/root/usr/share/nethesis/NethServer/Module/Nat.php
@@ -126,7 +126,7 @@ class Nat extends \Nethgui\Controller\AbstractController
         $tmp = array();
         $tmp[] = array("", "-");
         foreach ($this->hosts as $k => $v) {
-            $tmp[] = array($v['type'].";".$k, $k." (".$v['Description'].")");
+            $tmp[] = array("host;".$k, $k." (".$v['Description'].")");
         }
 
         $ds = array();


### PR DESCRIPTION
All host objects must be expressed in the form 'host;<name>'
to be correctly translated by the NethServer::Firewall perl library.
Before the fix, hosts with DHCP reservation were
referenced using the format 'local;<name>'

NethServer/dev#5417