### PR TITLE
shorewall: do not load ipt_ULOG kernel module

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -43,6 +43,7 @@ my @templates = qw(
     /etc/shorewall/tcinterfaces
     /etc/shorewall/tcpri
     /etc/shorewall/nat
+    /etc/shorewall/helpers
     /etc/lsm/lsm.conf
     /etc/firehol/fireqos.conf
 );

--- a/root/etc/e-smith/templates/etc/shorewall/helpers/10base
+++ b/root/etc/e-smith/templates/etc/shorewall/helpers/10base
@@ -1,0 +1,15 @@
+#
+# Shorewall version 5 - Helpers File
+#
+# /usr/share/shorewall/helpers
+#
+#	This file loads the kernel helper modules.
+#
+#	THE ORDER OF THE COMMANDS BELOW IS IMPORTANT!!!!!! You MUST load in
+#	dependency order. i.e., if M2 depends on M1 then you must load M1
+#	before you load M2.
+#
+#  If you need to modify this file, copy it to /etc/shorewall and modify the
+#  copy.
+#
+###############################################################################

--- a/root/etc/e-smith/templates/etc/shorewall/helpers/20helpers
+++ b/root/etc/e-smith/templates/etc/shorewall/helpers/20helpers
@@ -1,0 +1,44 @@
+#
+# Helpers
+#
+loadmodule ip_conntrack_amanda
+loadmodule ip_conntrack_ftp
+loadmodule ip_conntrack_h323
+loadmodule ip_conntrack_irc
+loadmodule ip_conntrack_netbios_ns
+loadmodule ip_conntrack_pptp
+loadmodule ip_conntrack_sip
+loadmodule ip_conntrack_tftp
+loadmodule ip_nat_amanda
+loadmodule ip_nat_ftp
+loadmodule ip_nat_h323
+loadmodule ip_nat_irc
+loadmodule ip_nat_pptp
+loadmodule ip_nat_sip
+loadmodule ip_nat_snmp_basic
+loadmodule ip_nat_tftp
+#
+# 2.6.20+ helpers
+#
+loadmodule nf_conntrack_ftp
+loadmodule nf_conntrack_h323
+loadmodule nf_conntrack_irc
+loadmodule nf_conntrack_netbios_ns
+loadmodule nf_conntrack_netlink
+loadmodule nf_conntrack_pptp
+loadmodule nf_conntrack_proto_gre
+loadmodule nf_conntrack_proto_sctp
+loadmodule nf_conntrack_proto_udplite
+loadmodule nf_conntrack_sip         sip_direct_media=0
+loadmodule nf_conntrack_tftp
+loadmodule nf_conntrack_sane
+loadmodule nf_nat_amanda
+loadmodule nf_nat_ftp
+loadmodule nf_nat_h323
+loadmodule nf_nat_irc
+loadmodule nf_nat
+loadmodule nf_nat_pptp
+loadmodule nf_nat_proto_gre
+loadmodule nf_nat_sip
+loadmodule nf_nat_snmp_basic
+loadmodule nf_nat_tftp

--- a/root/etc/e-smith/templates/etc/shorewall/helpers/30log
+++ b/root/etc/e-smith/templates/etc/shorewall/helpers/30log
@@ -1,0 +1,11 @@
+#
+# While not actually helpers, these are included here so that
+# LOG_BACKEND can work correctly. Not all of them will be
+# loaded, since at least one of them will be an alias on any
+# given system.
+#
+loadmodule ipt_LOG
+loadmodule nf_log_ipv4
+loadmodule xt_LOG
+loadmodule xt_NFLOG
+loadmodule nfnetlink_log


### PR DESCRIPTION
Avoid warning at startup:

  kernel: ipt_ULOG: ULOG: fail to register logger.


NethServer/dev#5490