### PR TITLE
fireqos: dynamically set act_connmark

### DIFF
--- a/root/etc/e-smith/templates/etc/firehol/fireqos.conf/10base
+++ b/root/etc/e-smith/templates/etc/firehol/fireqos.conf/10base
@@ -1,73 +1,7 @@
-{
-  use esmith::NetworksDB;
-  use esmith::ConfigDB;
-  use NethServer::Firewall;
- 
-  my $ndb = esmith::NetworksDB->open_ro() || die("Can't open networks db");
-  my $tdb = esmith::ConfigDB->open_ro('tc') || die("Can't open networks TC db");
-  my $fw = new NethServer::Firewall();
-  my $linklayer = $firewall{'TCLinklayer'} || 'ethernet';
+FIREQOS_CONNMARK_RESTORE=""
 
-  my @providers = $fw->getProviders();
-  my @classes = $tdb->get_all_by_prop('type' => 'class');
+modinfo act_connmark &>/dev/nul
 
-  sub getProviderName
-  {
-      my $needle = shift;
-      foreach my $p (@providers) {
-          if ($p->{'interface'} eq $needle) {
-              return $p->{'name'};
-          }
-      }
-      return "red-$needle";
-  }
-
-  sub outRate
-  {
-      my $direction = shift;
-      my $min = shift;
-      my $max = shift;
-      my $out = '';
-
-      if ($min || $max) {
-          $out .= "$direction";
-          if ($min > 0) {
-              $out .= " commit $min%";
-          }
-          if ($max > 0) {
-              $out .= " ceil $max%";
-          }
-      }
-
-      return $out;
-  }
-
-  $OUT .= 'FIREQOS_CONNMARK_RESTORE="act_connmark"';
-
-  foreach my $red ($ndb->red()) {
-      my $interface = $red->key;
-      my $in = $red->prop('FwInBandwidth') || next;
-      my $out = $red->prop('FwOutBandwidth') || next;
-
-      $OUT .= "\n\n";
-
-      $OUT .= "interface $interface ".getProviderName($interface)." bidirectional input rate ${in}kbit output rate ${out}kbit balanced $linklayer\n";
-
-      foreach my $class (@classes) {
-          my $name = $class->key;
-          my $mark = $class->prop('Mark') || next;
-          my $min_out = $class->prop('MinOutputRate') || 0;
-          my $max_out = $class->prop('MaxOutputRate') || 0;
-          my $min_in = $class->prop('MinInputRate') || 0;
-          my $max_in = $class->prop('MaxInputRate') || 0;
-
-          # skip empty classes
-          next if (!$min_out && !$max_out && !$min_in && !$max_in);
-
-          $OUT .= "\n";
-          $OUT .= "\tclass $name ".outRate('input',$min_in,$max_in)." ".outRate('output',$min_out,$max_out)."\n";
-          $OUT .= "\t\tmatch connmark 0x$mark\n";
-      }
-
-  }
-}
+if [ $? -eq 0 ]; then
+    FIREQOS_CONNMARK_RESTORE="act_connmark"
+fi

--- a/root/etc/e-smith/templates/etc/firehol/fireqos.conf/20rules
+++ b/root/etc/e-smith/templates/etc/firehol/fireqos.conf/20rules
@@ -1,0 +1,71 @@
+{
+  use esmith::NetworksDB;
+  use esmith::ConfigDB;
+  use NethServer::Firewall;
+ 
+  my $ndb = esmith::NetworksDB->open_ro() || die("Can't open networks db");
+  my $tdb = esmith::ConfigDB->open_ro('tc') || die("Can't open networks TC db");
+  my $fw = new NethServer::Firewall();
+  my $linklayer = $firewall{'TCLinklayer'} || 'ethernet';
+
+  my @providers = $fw->getProviders();
+  my @classes = $tdb->get_all_by_prop('type' => 'class');
+
+  sub getProviderName
+  {
+      my $needle = shift;
+      foreach my $p (@providers) {
+          if ($p->{'interface'} eq $needle) {
+              return $p->{'name'};
+          }
+      }
+      return "red-$needle";
+  }
+
+  sub outRate
+  {
+      my $direction = shift;
+      my $min = shift;
+      my $max = shift;
+      my $out = '';
+
+      if ($min || $max) {
+          $out .= "$direction";
+          if ($min > 0) {
+              $out .= " commit $min%";
+          }
+          if ($max > 0) {
+              $out .= " ceil $max%";
+          }
+      }
+
+      return $out;
+  }
+
+  foreach my $red ($ndb->red()) {
+      my $interface = $red->key;
+      my $in = $red->prop('FwInBandwidth') || next;
+      my $out = $red->prop('FwOutBandwidth') || next;
+
+      $OUT .= "\n\n";
+
+      $OUT .= "interface $interface ".getProviderName($interface)." bidirectional input rate ${in}kbit output rate ${out}kbit balanced $linklayer\n";
+
+      foreach my $class (@classes) {
+          my $name = $class->key;
+          my $mark = $class->prop('Mark') || next;
+          my $min_out = $class->prop('MinOutputRate') || 0;
+          my $max_out = $class->prop('MaxOutputRate') || 0;
+          my $min_in = $class->prop('MinInputRate') || 0;
+          my $max_in = $class->prop('MaxInputRate') || 0;
+
+          # skip empty classes
+          next if (!$min_out && !$max_out && !$min_in && !$max_in);
+
+          $OUT .= "\n";
+          $OUT .= "\tclass $name ".outRate('input',$min_in,$max_in)." ".outRate('output',$min_out,$max_out)."\n";
+          $OUT .= "\t\tmatch connmark 0x$mark\n";
+      }
+
+  }
+}


### PR DESCRIPTION
Set FIREQOS_CONNMARK_RESTORE="act_connmark" only
if running kernel supports it.

Installations with old kernel will still work even without reboot.

Thanks to @filippocarletti 

NethServer/dev#5484