### PR TITLE
Save packet marks for traffic from the firewall

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/80qos_fw
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/80qos_fw
@@ -1,0 +1,3 @@
+# 80qos_fw
+# save priority packet marks for traffic from the firewall itself
+SAVE          $FW               -               -     -       -       -       !0x00/0xff


### PR DESCRIPTION
NethServer/dev#5642

Squid can mark outgoing packets, we have to save the marks to shape
incoming traffic.