### PR TITLE
Check zone record integrity

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/hosts/50objects
+++ b/root/etc/e-smith/templates/etc/shorewall/hosts/50objects
@@ -9,8 +9,8 @@
     my $fw = NethServer::Firewall->new();
 
     foreach (grep { !$fw->isDanglingZoneRecord($_) } $ndb->zones()) {
-        my $i = $_->prop('Interface') || next;
-        my $n = $_->prop('Network') || next;
+        my $i = $_->prop('Interface') or next;
+        my $n = $_->prop('Network') or next;
         $OUT .= substr($_->key, 0, 5)."\t$i:$n\n";;
     } 
 }

--- a/root/etc/e-smith/templates/etc/shorewall/hosts/50objects
+++ b/root/etc/e-smith/templates/etc/shorewall/hosts/50objects
@@ -3,12 +3,14 @@
 #
 {
     use esmith::NetworksDB;
-    my $ndb = esmith::NetworksDB->open_ro();
+    use NethServer::Firewall;
 
-    foreach ($ndb->zones()) {
-        my $i = $_->prop('Interface') || "";
-        my $n = $_->prop('Network') || "";
-        next if ($i eq '' || $n eq '');
+    my $ndb = esmith::NetworksDB->open_ro();
+    my $fw = NethServer::Firewall->new();
+
+    foreach (grep { !$fw->isDanglingZoneRecord($_) } $ndb->zones()) {
+        my $i = $_->prop('Interface') || next;
+        my $n = $_->prop('Network') || next;
         $OUT .= substr($_->key, 0, 5)."\t$i:$n\n";;
     } 
 }

--- a/root/etc/e-smith/templates/etc/shorewall/zones/15objects
+++ b/root/etc/e-smith/templates/etc/shorewall/zones/15objects
@@ -3,12 +3,14 @@
 #
 {
     use esmith::NetworksDB;
-    my $ndb = esmith::NetworksDB->open_ro();
+    use NethServer::Firewall;
 
-    foreach ($ndb->zones()) {
-        my $i = $_->prop('Interface') || "";
-        my $n = $_->prop('Network') || "";
-        next if ($i eq '' || $n eq '');
+    my $ndb = esmith::NetworksDB->open_ro();
+    my $fw = NethServer::Firewall->new();
+
+    foreach (grep { !$fw->isDanglingZoneRecord($_) } $ndb->zones()) {
+        my $i = $_->prop('Interface') or next;
+        my $n = $_->prop('Network') or next;
         $OUT .= substr($_->key, 0, 5)."     ipv4\n";;
     }
 }


### PR DESCRIPTION
Avoid to expand an "invalid" zone record in shorewall templates. A zone
record can be invalidated by changing the referenced interface role.

NethServer/dev#5637

Here's an alternative approach based on UI validators, but does not cover all possible use cases: https://github.com/NethServer/nethserver-firewall-base/compare/master...DavidePrincipi:b5637 
