### PR TITLE
Adjust zone record references

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -152,9 +152,10 @@ event_actions($_, qw(
 
 $event = 'interface-update';
 
-event_actions($event,
-    'interface-config-write-pppoe' => '40'
-);
+event_actions($event, qw(
+    interface-config-write-pppoe 40
+    nethserver-firewall-adjustdb 60
+));
 event_templates($event,
     '/etc/ppp/chap-secrets',
     '/etc/ppp/pap-secrets'

--- a/root/etc/e-smith/events/actions/nethserver-firewall-adjustdb
+++ b/root/etc/e-smith/events/actions/nethserver-firewall-adjustdb
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use strict;
+use esmith::NetworksDB;
+
+my $ndb = esmith::NetworksDB->open() || die('Could not open NetworksDB');
+my $errors = 0;
+
+# If an interface becomes part of a logical interface its firewall zone
+# records are transferred to the logical interface
+foreach my $zone ($ndb->zones()) {
+    my $interface = $ndb->get($zone->prop('Interface'));
+    if(! $interface || !$interface->prop('role')) {
+        warn(sprintf("[ERROR] zone %s has a dangling Interface reference\n", $zone->key));
+        $errors ++;
+    }
+    if($interface->prop('role') eq 'bridged') {
+        $zone->set_prop('Interface', $interface->prop('bridge'));
+    } elsif($interface->prop('role') eq 'slave') {
+        $zone->set_prop('Interface', $interface->prop('master'));
+    }
+}
+
+# When a logical interface is removed, its successor inherits any reference
+# through the "interface-rename" action
+
+if($errors > 0) {
+    exit(1);
+}


### PR DESCRIPTION
If an interface becomes part of a logical interface its firewall zone
records are transferred to the logical interface.

The logical interface deletion is implemented by https://github.com/NethServer/nethserver-base/pull/144

NethServer/dev#5637

