### PR TITLE
Firewall rules UI: exclude not-supported role

### DIFF
--- a/root/usr/share/nethesis/NethServer/Tool/FirewallObjectsFinder.php
+++ b/root/usr/share/nethesis/NethServer/Tool/FirewallObjectsFinder.php
@@ -105,9 +105,10 @@ class FirewallObjectsFinder implements \IteratorAggregate, \Countable
 
     private function addSearchRoles(\Nethgui\System\PlatformInterface $platform, $text)
     {
+        $roles = array('green', 'red', 'blue', 'orange');
         $tmp = array();
         foreach ($platform->getDatabase('networks')->getAll() as $key => $props) {
-            if (isset($props['role'])) {
+            if (isset($props['role']) && in_array($props['role'], $roles)) {
                 $tmp[$props['role']] = '';
             }
         }


### PR DESCRIPTION
Rules for the hotspot role can't be safely applied
since they allow traffic which should be blocked.