### PR TITLE
spec: exclude Cockpit UI from base package

### DIFF
--- a/nethserver-firewall-base.spec
+++ b/nethserver-firewall-base.spec
@@ -57,7 +57,7 @@ cp -a api/* %{buildroot}/usr/libexec/nethserver/api/%{name}/
 
 %{genfilelist} %{buildroot} > %{name}-%{version}-%{release}-filelist
 grep -e php$ -e rst$ -e html$ -e cockpit %{name}-%{version}-%{release}-filelist > %{name}-%{version}-%{release}-filelist-ui
-grep -v /usr/share/nethesis/NethServer %{name}-%{version}-%{release}-filelist > %{name}-%{version}-%{release}-filelist-core
+grep -v -e /usr/share/nethesis/NethServer -e cockpit %{name}-%{version}-%{release}-filelist > %{name}-%{version}-%{release}-filelist-core
 
 %files -f %{name}-%{version}-%{release}-filelist-core
 %defattr(-,root,root)


### PR DESCRIPTION
Previously the Cockpit UI was present even if nethserver-firewall-base-ui wasn't installed.

The API is still inside nethserver-firewall-base package because it could be useful for automation.

