### PR TITLE
Sudo permission for settings delegation

### DIFF
--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -208,7 +208,7 @@ export default {
         function(error) {
           console.error(error);
         },
-        false
+        true // sudo
       );
     },
     toggleSettingsMACValidation() {
@@ -261,7 +261,7 @@ export default {
             function(error, data) {
               console.error(error, data);
             },
-            false
+            true //sudo
           );
         },
         function(error, data) {
@@ -280,7 +280,7 @@ export default {
             console.error(e);
           }
         },
-        false
+        true //sudo 
       );
     }
   }


### PR DESCRIPTION
Without this patch the setting page can't be edit from non-root users.