### PR TITLE
Firewall August fixes

### DIFF
--- a/ui/src/views/LocalRules.vue
+++ b/ui/src/views/LocalRules.vue
@@ -56,7 +56,7 @@
           </div>
           <div class="list-view-pf-actions">
             <button
-              @click="r.status == 'disabled' ? enableRule(r) : openEditRule(r, false)"
+              @click="r.status == 'disabled' ? toggleEnableRule(r) : openEditRule(r, false)"
               :class="['btn btn-default', r.status == 'disabled' ? 'btn-primary' : '']"
             >
               <span
@@ -77,11 +77,11 @@
               </button>
               <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight9">
                 <li>
-                  <a @click="enableRule(r)">
+                  <a @click="r.status == 'enabled' ? toggleEnableRule(r) : openEditRule(r, false)">
                     <span
-                      :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-check', 'span-right-margin']"
+                      :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-edit', 'span-right-margin']"
                     ></span>
-                    {{r.status == 'enabled' ? $t('disable') : $t('enable')}}
+                    {{r.status == 'enabled' ? $t('disable') : $t('edit')}}
                   </a>
                 </li>
                 <li @click="openEditRule(r, true)">
@@ -1615,7 +1615,7 @@ export default {
 
       $("#createRuleModal").modal("show");
     },
-    enableRule(r) {
+    toggleEnableRule(r) {
       var context = this;
 
       var ruleObj = {

--- a/ui/src/views/PortForward.vue
+++ b/ui/src/views/PortForward.vue
@@ -943,6 +943,16 @@ export default {
         : this.newPf.DstHost;
 
       this.newPf.name = duplicate ? "" : this.newPf.name;
+
+      this.newPf.SrcDisabled = !(
+        this.newPf.Proto.toLowerCase().includes("tcp") ||
+        this.newPf.Proto.toLowerCase().includes("udp")
+      );
+      this.newPf.DstDisabled = !(
+        this.newPf.Proto.toLowerCase().includes("tcp") ||
+        this.newPf.Proto.toLowerCase().includes("udp")
+      );
+
       this.$forceUpdate();
       $("#createPFModal").modal("show");
     },

--- a/ui/src/views/PortForward.vue
+++ b/ui/src/views/PortForward.vue
@@ -570,7 +570,7 @@ export default {
         this.newPf.Proto != "tcpudp"
       ) {
         this.newPf.Dst = null;
-        this.newPf.Src = null;
+        this.newPf.Src = "";
         this.newPf.SrcType = null;
       }
     },
@@ -825,7 +825,7 @@ export default {
           try {
             success = JSON.parse(success);
             context.view.isLoaded = true;
-            context.pfList = success.portforward;
+            context.pfList = Object.keys(success.portforward).length == 0 ? null : success.portforward;
           } catch (e) {
             console.error(e);
             context.view.isLoaded = true;

--- a/ui/src/views/PortForward.vue
+++ b/ui/src/views/PortForward.vue
@@ -137,7 +137,7 @@
                   </div>
                   <div class="col-sm-2">
                     <button
-                      @click="p.status == 'disabled' ? enablePF(p, host) : openEditPF(p, host, false)"
+                      @click="p.status == 'disabled' ? toggleEnablePF(p, host) : openEditPF(p, host, false)"
                       :class="['btn btn-default', p.status == 'disabled' ? 'btn-primary' : '']"
                     >
                       <span
@@ -158,11 +158,11 @@
                       </button>
                       <ul class="dropdown-menu dropdown-menu-right">
                         <li>
-                          <a @click="enablePF(p, host)">
+                          <a @click="p.status == 'enabled' ? toggleEnablePF(p, host) : openEditPF(p, host, false)">
                             <span
-                              :class="['fa', p.status == 'enabled' ? 'fa-lock' : 'fa-check', 'span-right-margin']"
+                              :class="['fa', p.status == 'enabled' ? 'fa-lock' : 'fa-edit', 'span-right-margin']"
                             ></span>
-                            {{p.status == 'enabled' ? $t('disable') : $t('enable')}}
+                            {{p.status == 'enabled' ? $t('disable') : $t('edit')}}
                           </a>
                         </li>
                         <li>
@@ -981,8 +981,6 @@ export default {
         Log: context.newPf.Log ? "info" : "none",
         status: context.newPf.isEdit
           ? context.newPf.status
-            ? "enabled"
-            : "disabled"
           : "enabled"
       };
 
@@ -1046,19 +1044,27 @@ export default {
         }
       );
     },
-    enablePF(p, host) {
+    toggleEnablePF(p, host) {
       var context = this;
 
       var pfObj = {
         action: "update",
         name: p.name,
-        Src: p.Src,
-        DstHost: host,
-        Dst: p.Dst,
+        Src: p.Src
+          ? p.Src.split(",").map(function(item) {
+              return item.trim();
+          })
+          : [],
+        DstHost: p.DstHostFull
+          ? { name: p.DstHost, type: "host" }
+          : { name: p.DstHost, type: "raw" },
+        Dst: p.Dst ? p.Dst : "",
         Proto: p.Proto,
         Description: p.Description,
         OriDst: p.OriDst == "any" ? "" : p.OriDst,
-        Allow: p.Allow,
+        Allow: p.Allow.length == 0
+          ? []
+          : p.Allow.split("\n"),
         Log: p.Log ? "info" : "none",
         status: p.status == "enabled" ? "disabled" : "enabled"
       };

--- a/ui/src/views/Rules.vue
+++ b/ui/src/views/Rules.vue
@@ -67,7 +67,7 @@
           </div>
           <div class="list-view-pf-actions">
             <button
-              @click="r.status == 'disabled' ? enableRule(r) : openEditRule(r, false)"
+              @click="r.status == 'disabled' ? toggleEnableRule(r) : openEditRule(r, false)"
               :class="['btn btn-default', r.status == 'disabled' ? 'btn-primary' : '']"
             >
               <span
@@ -88,11 +88,11 @@
               </button>
               <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight9">
                 <li>
-                  <a @click="enableRule(r)">
+                  <a @click="r.status == 'enabled' ? toggleEnableRule(r) : openEditRule(r, false)">
                     <span
-                      :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-check', 'span-right-margin']"
+                      :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-edit', 'span-right-margin']"
                     ></span>
-                    {{r.status == 'enabled' ? $t('disable') : $t('enable')}}
+                    {{r.status == 'enabled' ? $t('disable') : $t('edit')}}
                   </a>
                 </li>
                 <li @click="openEditRule(r, true)">
@@ -1728,7 +1728,7 @@ export default {
 
       $("#createRuleModal").modal("show");
     },
-    enableRule(r) {
+    toggleEnableRule(r) {
       var context = this;
 
       var ruleObj = {

--- a/ui/src/views/TrafficShaping.vue
+++ b/ui/src/views/TrafficShaping.vue
@@ -254,7 +254,7 @@
         </div>
         <div class="list-view-pf-actions">
           <button
-            @click="r.status == 'disabled' ? enableRule(r) : openEditRule(r, false)"
+            @click="r.status == 'disabled' ? toggleEnableRule(r) : openEditRule(r, false)"
             :class="['btn btn-default', r.status == 'disabled' ? 'btn-primary' : '']"
           >
             <span
@@ -275,11 +275,11 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight9">
               <li>
-                <a @click="enableRule(r)">
+                <a @click="r.status == 'enabled' ? toggleEnableRule(r) : openEditRule(r, false)">
                   <span
-                    :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-check', 'span-right-margin']"
+                    :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-edit', 'span-right-margin']"
                   ></span>
-                  {{r.status == 'enabled' ? $t('disable') : $t('enable')}}
+                  {{r.status == 'enabled' ? $t('disable') : $t('edit')}}
                 </a>
               </li>
               <li @click="openEditRule(r, true)">
@@ -2422,7 +2422,7 @@ export default {
 
       $("#createRuleModal").modal("show");
     },
-    enableRule(r) {
+    toggleEnableRule(r) {
       var context = this;
 
       var ruleObj = {

--- a/ui/src/views/WAN.vue
+++ b/ui/src/views/WAN.vue
@@ -311,7 +311,7 @@
         </div>
         <div class="list-view-pf-actions">
           <button
-            @click="r.status == 'disabled' ? enableRule(r) : openEditRule(r, false)"
+            @click="r.status == 'disabled' ? toggleEnableRule(r) : openEditRule(r, false)"
             :class="['btn btn-default', r.status == 'disabled' ? 'btn-primary' : '']"
           >
             <span
@@ -332,11 +332,11 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight9">
               <li>
-                <a @click="enableRule(r)">
+                <a @click="r.status == 'enabled' ? toggleEnableRule(r) : openEditRule(r, false)">
                   <span
-                    :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-check', 'span-right-margin']"
+                    :class="['fa', r.status == 'enabled' ? 'fa-lock' : 'fa-edit', 'span-right-margin']"
                   ></span>
-                  {{r.status == 'enabled' ? $t('disable') : $t('enable')}}
+                  {{r.status == 'enabled' ? $t('disable') : $t('edit')}}
                 </a>
               </li>
               <li @click="openEditRule(r, true)">
@@ -2365,7 +2365,7 @@ export default {
 
       $("#createRuleModal").modal("show");
     },
-    enableRule(r) {
+    toggleEnableRule(r) {
       var context = this;
 
       var ruleObj = {


### PR DESCRIPTION
- Added "edit rule" in the kebab menu of these pages:
  - Local rules
  - Rules
  - Traffic shaping
  - WAN
  - Port forward
- Fixed port forwarding input form: while editing a port forward that uses a protocol different from TCP/UDP, source port and destination port inputs are now disabled
- Fixed port forwarding: disabling a rule now data is preserved and managed as expected