### PR TITLE
Port forward for non-TCP/UDP protocols

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/50pf
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/50pf
@@ -34,7 +34,7 @@
         $status = $pf->prop('status') || "disabled";
         $log = $pf->prop('Log') || "";
         next unless ($status eq "enabled");
-        $src = $pf->prop('Src') || next;
+        $src = $pf->prop('Src') || '-';
         $dstHost = $pf->prop('DstHost') || next;
         $srcHost = $pf->prop('SrcHost') || "";
         $srcHost = $fw->getAddress($srcHost);


### PR DESCRIPTION
Port forward rules on protocols such as AH, GRE and ESP are now included in Shorewall rules template.