### PR TITLE
Fixed icons for L7 apps in traffic shaping

### DIFF
--- a/ui/src/views/TrafficShaping.vue
+++ b/ui/src/views/TrafficShaping.vue
@@ -378,7 +378,9 @@
                 :title="mapTitleService(r)"
                 class="list-view-pf-additional-info-item"
               >
-                <span class="fa fa-cogs"></span>
+                <span
+                  :class="['fa', r.Service && r.Service.type == 'application' ? r.Service.icon : 'fa-cogs']"
+                ></span>
                 <strong>{{r.Service && r.Service.name}}</strong>
               </div>
               <div


### PR DESCRIPTION
Priority rules table now shows appropriate icons for L7 applications

https://github.com/NethServer/dev/issues/5846