### PR TITLE
Informative description for MAC validation (IP/MAC binding)

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -444,7 +444,7 @@
         "external_ping": "Ping from Internet",
         "mac": "MAC validation (IP/MAC binding)",
         "allowed": "Allowed",
-        "allow_mac": "Allow hosts without IP/MAC binding (DHCP reservation)",
+        "block_mac": "Block hosts not listed in DHCP reservations",
         "settings_updated_ok": "Settings updated successfully!",
         "settings_updated_error": "Settings not updated.",
         "portforward": "Port forward",
@@ -514,6 +514,8 @@
         "pf_origin_port": "Insert a single port, a list of comma-separated ports, or a port range using \":\" as separator like \"100:200\".",
         "rules_source": "You may insert an IP address or a CIDR if you do not want to create a host or CIDR object.",
         "rules_destination": "You may insert an IP address or a CIDR if you do not want to create a host or CIDR object.",
-        "objects_ports": "Supported syntax: comma-separated port list or port range (i.e. 10000-20000)"
+        "objects_ports": "Supported syntax: comma-separated port list or port range (i.e. 10000-20000)",
+        "mac_validation": "Requests from IP addresses listed in DHCP reservations are allowed only if are originated from the associated MAC address (even if DHCP is disabled).",
+        "mac_validation_policy": "Requests from IP addresses not listed in DHCP reservations are blocked. Ensure admin hosts are listed in DHCP reservations."
     }
 }

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -60,7 +60,15 @@
           <label
             class="col-sm-2 control-label"
             for="textInput-modal-markup"
-          >{{$t('enabled')}}</label>
+          >
+            {{$t('enabled')}}
+            <doc-info
+              :placement="'top'"
+              :title="$t('settings.mac')"
+              :chapter="'mac_validation'"
+              :inline="true"
+            ></doc-info>
+          </label>
           <div class="col-sm-5">
             <toggle-button
               class="min-toggle"
@@ -84,7 +92,15 @@
           <label
             class="col-sm-2 control-label"
             for="textInput-modal-markup"
-          >{{$t('settings.allow_mac')}}</label>
+          >
+            {{$t('settings.block_mac')}}
+            <doc-info
+              :placement="'top'"
+              :title="$t('settings.mac')"
+              :chapter="'mac_validation_policy'"
+              :inline="true"
+            ></doc-info>
+          </label>
           <div class="col-sm-5">
             <input type="checkbox" v-model="settings.mac.MACValidationPolicy" class="form-control">
             <span
@@ -197,7 +213,7 @@ export default {
 
           // mac
           context.settings.mac.MACValidationPolicy =
-            success.settings.MACValidationPolicy == "accept";
+            success.settings.MACValidationPolicy == "drop";
           context.settings.mac.MACValidation =
             success.settings.MACValidation == "enabled";
 
@@ -224,8 +240,8 @@ export default {
         HairpinNat: context.settings.pf.HairpinNat ? "enabled" : "disabled",
         Policy: context.settings.internet.Policy ? "permissive" : "strict",
         MACValidationPolicy: context.settings.mac.MACValidationPolicy
-          ? "accept"
-          : "drop",
+          ? "drop"
+          : "accept",
         MACValidation: context.settings.mac.MACValidation
           ? "enabled"
           : "disabled"


### PR DESCRIPTION
Informative description for MAC validation (IP/MAC binding) controls:

- **MAC validation** toggle switch
- **MAC validation policy** checkbox

Improved label text for **MAC validation policy** checkbox

https://github.com/NethServer/dev/issues/5883