### PR TITLE
firewall lib: check for ndpi lock

### DIFF
--- a/NethServer/Firewall.pm
+++ b/NethServer/Firewall.pm
@@ -662,13 +662,15 @@ sub listZones($)
 
 =head2 isNdpiEnabled
 
-Return 1 if the current xt_ndpi module is loaded, 0 otherwise
+Return 1 if the current xt_ndpi module is loaded
+and ndpi kernel module has not failed the update.
+Return 0 otherwise.
 
 =cut
 
 sub isNdpiEnabled
 {
-    return ( -d '/proc/net/xt_ndpi/');
+    return ( -d '/proc/net/xt_ndpi/') && ( ! -f '/var/run/ndpi-lock');
 }
 
 


### PR DESCRIPTION
Avoid enabling ndpi rules if something failed during kernel module
update.
This workaround should avoid ndpi version mismatch between kernel module
and user space libraries.

NethServer/dev#5890