### PR TITLE
ui: use kbit unit for tc classes

### DIFF
--- a/ui/src/views/TrafficShaping.vue
+++ b/ui/src/views/TrafficShaping.vue
@@ -454,7 +454,7 @@
                     class="col-sm-2 col-xs-2"
                     type="radio"
                     v-model="newTc.Unit"
-                    value="kbps"
+                    value="kbit"
                   />
                   <label
                     class="col-sm-10 col-xs-10 control-label text-align-left"


### PR DESCRIPTION
FireQOS uses kpbs unit for "kilobytes per second" instead
of "kilobits per second".
Bandwidth should be always expressed in kilobits.

NethServer/dev#5897