### PR TITLE
ndpi lib: suppress warning

### DIFF
--- a/NethServer/Database/Ndpi.pm
+++ b/NethServer/Database/Ndpi.pm
@@ -38,6 +38,7 @@ sub _read_db
     while ($line = <$fh>) {
         chomp($line);
         my ($id, $mark, $mask, $name, $count) = split(m([\s#/]+), $line);
+        next if ($mark eq 'disabled');
         $db->{$id} = "ndpi|name|$name|mark|$mark|mask|$mask|count|$count";
     }
     close($fh);


### PR DESCRIPTION
Avoid warning on /etc/shorewall/mangle template:
 Use of uninitialized value $count in concatenation (.) or string at
 /usr/share/perl5/vendor_perl/NethServer/Database/Ndpi.pm line 41, <$fh> line 308