### PR TITLE
port forward: remove hairpin for blue and orange zones

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/50pf
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/50pf
@@ -23,8 +23,6 @@
     my @sources = ('net');
     if ($hairpin eq 'enabled') {
         @sources = ('net','loc');
-        if (defined($ndb->blue)) { push @sources, 'blue'; }
-        if (defined($ndb->orange)) { push @sources, 'orang'; }
     }
 
     my $fw = new NethServer::Firewall();


### PR DESCRIPTION
Hairpin implementation was missing the snat part and
never worked nor on blue nor on orange.

NethServer/dev#6045