### PR TITLE
post-restore: support skip-network option

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -176,6 +176,7 @@ event_actions('static-routes-save', qw(
 
 event_actions('post-restore-config', qw(
     nethserver-firewall-base-disable 01
+    nethserver-firewall-base-network-reset 02
     nethserver-firewall-base-condenable 98
 ));
 

--- a/root/etc/e-smith/events/actions/nethserver-firewall-base-network-reset
+++ b/root/etc/e-smith/events/actions/nethserver-firewall-base-network-reset
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use warnings;
+use strict;
+use esmith::NetworksDB;
+use esmith::ConfigDB;
+
+my $ndb = esmith::NetworksDB->open();
+my $rdb = esmith::ConfigDB->open('fwrules');
+
+# ARGV[0] is the name of the event
+# ARGV[1] is the first real parameter
+if (defined($ARGV[1]) && $ARGV[1] eq '--skip-network') {
+
+    # Delete all red providers
+    foreach my $item ($ndb->get_all_by_prop('type'=>'provider')) {
+        $item->delete();
+    }
+
+    # Delete dangling zones
+    foreach my $item ($ndb->get_all_by_prop('type'=>'zone')) {
+        my $i = $item->prop('Interface') || next;
+        if (!defined($ndb->get($i))) {
+            $item->delete();
+        }
+    }
+
+    # Disable rules using deleted objects
+    foreach my $item ($rdb->get_all()) {
+        foreach my $p (qw(Src Dst)) {
+            my $v = $item->prop($p);
+            # Check for non-existing zones
+            if ($v =~ /^zone;(.*)$/) {
+                if(!defined($ndb->get($1))) {
+                    $item->set_prop('status', 'disabled');
+                }
+            }
+            # Check for non-existing roles
+            if ($v =~ /^role;(.*)$/) {
+                if(scalar($ndb->get_all_by_prop('role', $1)) <= 0) {
+                    $item->set_prop('status', 'disabled');
+                }
+            }
+        }
+    }
+}

--- a/root/etc/e-smith/events/actions/nethserver-firewall-base-network-reset
+++ b/root/etc/e-smith/events/actions/nethserver-firewall-base-network-reset
@@ -28,9 +28,7 @@ use esmith::ConfigDB;
 my $ndb = esmith::NetworksDB->open();
 my $rdb = esmith::ConfigDB->open('fwrules');
 
-# ARGV[0] is the name of the event
-# ARGV[1] is the first real parameter
-if (defined($ARGV[1]) && $ARGV[1] eq '--skip-network') {
+if (grep(/^--skip-network$/, @ARGV)) {
 
     # Delete all red providers
     foreach my $item ($ndb->get_all_by_prop('type'=>'provider')) {


### PR DESCRIPTION
Delete dangling objects and disable rules with not-existing objects

See NethServer/nethserver-backup-config#41

NethServer/dev#6099