### PR TITLE
providers: cleanup stale status

### DIFF
--- a/root/etc/e-smith/events/actions/providers-cleanup
+++ b/root/etc/e-smith/events/actions/providers-cleanup
@@ -55,7 +55,9 @@ if (scalar(@providers) >= 2) {
 my @status_files = glob('/var/lib/shorewall/*.status');
 foreach (@status_files) {
     my $interface = basename($_,('.status'));
-    if (!defined($ndb->get($interface))) {
+    my $i = $ndb->get($interface) || undef;
+    my $role = $ndb->get_prop($interface, 'role') || '';
+    if (!defined($i) || $role ne 'red') {
         print "[INFO] Removing status file '$_'\n";
         unlink($_);;
     }


### PR DESCRIPTION
Delete also the status referring to existing
network interface but with a non-red role.

NethServer/dev#6105