### PR TITLE
wan-update: restart shorewall if needed

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-shorewall-wan-update
+++ b/root/etc/e-smith/events/actions/nethserver-shorewall-wan-update
@@ -59,6 +59,10 @@ fi
 if [ ${STATE} = up ]; then
   logger -i -p kern.info -t Shorewall Enabling device ${DEVICE}
   /usr/sbin/shorewall enable ${DEVICE} 2>>/var/log/firewall.log
+  if /usr/sbin/ip route | /usr/bin/grep -q -E '^default via'; then
+      # Force Shorewall restart if the defaut route is set
+      /usr/sbin/shorewall restart
+  fi
 else
   logger -i -p kern.info -t Shorewall Disabling device ${DEVICE}
   /usr/sbin/shorewall disable ${DEVICE} 2>>/var/log/firewall.log


### PR DESCRIPTION
Clean up default route when a firewall restarts after all providers have
been set to disabled.

This is a fix for a corner case. Conditions to reproduce the problem:

- 2 or more WAN providers configured in active-backup mode
- both providers should be disabled
- reboot the firewall while all providers are still disabled

NethServer/dev#6157