### PR TITLE
Enable hairpin NAT for OpenvPN RW

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/50pf
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/50pf
@@ -20,11 +20,16 @@
 
     my $nfqueue = $firewall{'nfqueue'} || 'disabled';
     my $hairpin = $firewall{'HairpinNat'} || 'disabled';
+    my $ovpn_installed = (-f '/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/status');
+    my $ovpn_status = ${'openvpn@host-to-net'}{'status'} || 'disabled';
     my @sources = ('net');
     if ($hairpin eq 'enabled') {
         @sources = ('net','loc');
         if (defined($ndb->blue)) { push @sources, 'blue'; }
         if (defined($ndb->orange)) { push @sources, 'orang'; }
+        if ($ovpn_installed && $ovpn_status eq 'enabled') {
+            push(@sources, 'ovpn');
+        }
     }
 
     my $fw = new NethServer::Firewall();

--- a/root/etc/e-smith/templates/etc/shorewall/snat/51pflanmasq
+++ b/root/etc/e-smith/templates/etc/shorewall/snat/51pflanmasq
@@ -14,17 +14,6 @@
     my $fw = new NethServer::Firewall();
     my $ndb = esmith::NetworksDB->open_ro();
     $db = esmith::ConfigDB->open("portforward") || die "Can't open portforward database: $!\n";
-    my $ovpn_installed = (-f '/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/status');
-    my $ovpn_status = ${'openvpn@host-to-net'}{'status'} || 'disabled';
-    my $ovpn_net = '';
-    my $ovpn_ip = '';
-    if ($ovpn_installed && $ovpn_status eq 'enabled') {
-        $ovpn_net = esmith::util::computeLocalNetworkShortSpec(${'openvpn@host-to-net'}{'Network'},${'openvpn@host-to-net'}{'Netmask'});
-        my ($tot, $first, $last) = esmith::util::computeHostRange(${'openvpn@host-to-net'}{'Network'},${'openvpn@host-to-net'}{'Netmask'});
-        $ovpn_ip = esmith::util::IPquadToAddr($first); # convert to integer
-        $ovpn_ip = esmith::util::IPaddrToQuad($ovpn_ip+1);
-    }
-
     foreach my $pf ( $db->get_all_by_prop('type' => 'pf') ) {
         $proto = $pf->prop('Proto') || 'tcp,udp';
         $status = $pf->prop('status') || "disabled";
@@ -79,9 +68,6 @@
         foreach ($ndb->get_by_role('green')) {
             my $net = esmith::util::computeLocalNetworkShortSpec($_->prop('ipaddr'),$_->prop('netmask'));
             $OUT .= "SNAT(".$_->prop('ipaddr').")\t$net\t".$interface.":$dstHost\t$proto\t$dst\n";
-            if ($ovpn_ip) {
-                $OUT .= "SNAT($ovpn_ip)\t$ovpn_net\t".$_->key.":$dstHost\t$proto\t$dst\n"
-            }
         }
 
         foreach ($ndb->get_by_role('blue')) {

--- a/root/etc/e-smith/templates/etc/shorewall/snat/51pflanmasq
+++ b/root/etc/e-smith/templates/etc/shorewall/snat/51pflanmasq
@@ -14,6 +14,17 @@
     my $fw = new NethServer::Firewall();
     my $ndb = esmith::NetworksDB->open_ro();
     $db = esmith::ConfigDB->open("portforward") || die "Can't open portforward database: $!\n";
+    my $ovpn_installed = (-f '/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/status');
+    my $ovpn_status = ${'openvpn@host-to-net'}{'status'} || 'disabled';
+    my $ovpn_net = '';
+    my $ovpn_ip = '';
+    if ($ovpn_installed && $ovpn_status eq 'enabled') {
+        $ovpn_net = esmith::util::computeLocalNetworkShortSpec(${'openvpn@host-to-net'}{'Network'},${'openvpn@host-to-net'}{'Netmask'});
+        my ($tot, $first, $last) = esmith::util::computeHostRange(${'openvpn@host-to-net'}{'Network'},${'openvpn@host-to-net'}{'Netmask'});
+        $ovpn_ip = esmith::util::IPquadToAddr($first); # convert to integer
+        $ovpn_ip = esmith::util::IPaddrToQuad($ovpn_ip+1);
+    }
+
     foreach my $pf ( $db->get_all_by_prop('type' => 'pf') ) {
         $proto = $pf->prop('Proto') || 'tcp,udp';
         $status = $pf->prop('status') || "disabled";
@@ -68,6 +79,9 @@
         foreach ($ndb->get_by_role('green')) {
             my $net = esmith::util::computeLocalNetworkShortSpec($_->prop('ipaddr'),$_->prop('netmask'));
             $OUT .= "SNAT(".$_->prop('ipaddr').")\t$net\t".$interface.":$dstHost\t$proto\t$dst\n";
+            if ($ovpn_ip) {
+                $OUT .= "SNAT($ovpn_ip)\t$ovpn_net\t".$_->key.":$dstHost\t$proto\t$dst\n"
+            }
         }
 
         foreach ($ndb->get_by_role('blue')) {


### PR DESCRIPTION
I have 2 major doubts on this PR:
- ~~OpenVPN traffic should already work and~~ no SNAT should be needed
- with this change in place, access to hosts inside blue and orange will still work but always without SNAT, which I think should be required (at lease following [shorewall doc](https://shorewall.org/FAQ.htm#DNS-DNAT))

NethServer/dev#6165