### PR TITLE
Remove reverse order for QoS Rules

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/40priorities
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/40priorities
@@ -13,7 +13,7 @@
     my $tdb = esmith::ConfigDB->open_ro('tc');
     our @providers = $fw->getProviders();
 
-    foreach my $rule ( reverse($fw->getTcRules()) ) {
+    foreach my $rule ( $fw->getTcRules() ) {
         my $src = $rule->prop("Src") || next;
         my $dst = $rule->prop("Dst") || next;
         my $status = $rule->prop("status") || 'disabled';


### PR DESCRIPTION
Write rules in tcpost (mangle) in the same order they are displayed  in the web UI.

NethServer/dev#6203