### PR TITLE
Restore connmark for traffic to the firewall

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/20ndpi
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/20ndpi
@@ -17,7 +17,9 @@
 
    $OUT .= "# Restore the connection mark into the current packet.\n";
    $OUT .= "RESTORE:F       -               -               -\n";
-   $OUT .= "# Restore the connection mark for packets from firewall (Squid).\n";
-   $OUT .= "# This is usefull only for QoS\n";
+   $OUT .= "# Restore the connection mark for packets from/to firewall (Squid).\n";
+   $OUT .= "# This is useful only for QoS\n";
    $OUT .= "RESTORE        \$FW             -               -\n";
+   $OUT .= "RESTORE        -                \$FW            -\n";
+
 }


### PR DESCRIPTION
This will fix inbound traffic shaping for traffic to the firewall itself.
It adds a CONNMARK restore in the mangle INPUT chain.