### PR TITLE
ui: add missing label

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -122,7 +122,8 @@
         "ndpi": "nDPI",
         "details_for": "Details for",
         "name": "Name",
-        "counter": "Counter"
+        "counter": "Counter",
+        "unknown": "Unknown"
     },
     "wan": {
         "title": "WAN",


### PR DESCRIPTION
This is how the dashboard looks like:
![Screenshot from 2020-07-01 12-33-15](https://user-images.githubusercontent.com/804596/86249645-df679580-bbaf-11ea-9c86-6ef722b81a33.png)

NethServer/dev#6206