### PR TITLE
Support MAC address objects inside firewall rules

### DIFF
--- a/NethServer/Firewall.pm
+++ b/NethServer/Firewall.pm
@@ -971,22 +971,22 @@ sub countReferences($$)
     my $key = shift;
 
     my $typeMap = {
-	'provider' => 'provider',
-	'host-group' => 'host-group',
-	'host' => 'host',
-	'remote' => 'host',
-	'local' => 'host',
-	'fwservice' => 'fwservice',
-	'zone' => 'zone',
-	'ethernet' => 'role',
-	'bridge' => 'role',
-	'vlan' => 'role',
-	'alias' => 'role',
-	'bond' => 'role',
-    'cidr', => 'cidr',
-    'time', => 'time',
-    'iprange' => 'iprange',
-    'mac' => 'mac'
+        'provider' => 'provider',
+        'host-group' => 'host-group',
+        'host' => 'host',
+        'remote' => 'host',
+        'local' => 'host',
+        'fwservice' => 'fwservice',
+        'zone' => 'zone',
+        'ethernet' => 'role',
+        'bridge' => 'role',
+        'vlan' => 'role',
+        'alias' => 'role',
+        'bond' => 'role',
+        'cidr', => 'cidr',
+        'time', => 'time',
+        'iprange' => 'iprange',
+        'mac' => 'mac'
 	};
 
     my $db = esmith::DB::db->open_ro($dbName);

--- a/NethServer/Firewall.pm
+++ b/NethServer/Firewall.pm
@@ -136,6 +136,7 @@ sub new
     my $cdb_path = shift || '';
     my $pfdb_path = shift || 'portforward';
     my $ftdb_path = shift || 'fwtimes';
+    my $mdb_path = shift || 'macs';
 
     my $self = {
         sdb_path => $sdb_path,
@@ -144,7 +145,8 @@ sub new
         fdb_path => $fdb_path,
         pfdb_path => $pfdb_path,
         ftdb_path => $ftdb_path,
-        cdb_path => $cdb_path
+        cdb_path => $cdb_path,
+        mdb_path => $mdb_path
     };
     bless $self, $class;
     $self->_initialize();
@@ -163,6 +165,7 @@ sub _initialize()
     $self->{'cdb'} = esmith::ConfigDB->open_ro($self->{'cdb_path'});
     $self->{'pfdb'} = esmith::ConfigDB->open_ro($self->{'pfdb_path'});
     $self->{'ftdb'} = esmith::ConfigDB->open_ro($self->{'ftdb_path'});
+    $self->{'mdb'} = esmith::ConfigDB->open_ro($self->{'mdb_path'});
 }
 
 =head2 getAddress(id, expand_zone = 0)
@@ -227,10 +230,12 @@ sub getAddress($)
             } else { 
                 return substr($key, 0, 5); # truncate zone name to 5 chars
             }
-        } elsif ( $db eq 'cidr') {
+        } elsif ( $db eq 'cidr' ) {
             return $self->_getCidrAddress($key);
-        } elsif ( $db eq 'iprange') {
+        } elsif ( $db eq 'iprange' ) {
             return $self->_getIpRangeAddress($key);
+        } elsif ($db eq 'mac' ) {
+            return $self->_getMacAddress($key);
         }
     } 
 
@@ -471,6 +476,21 @@ sub getZone($)
         $original_value = $value;
         my @tmp = split('-',$value);
         $value = $tmp[0];
+    }
+
+    # check mac address in Shorewall format
+    if ($value =~ m/^\~([0-9a-fA-F][0-9a-fA-F]\-){5}([0-9a-fA-F][0-9a-fA-F])$/) {
+        # reverse zone search inside macs db
+        my $mk = substr($value, 1);
+        $mk =~ s/\-/:/g;
+        foreach my $m ($self->{'mdb'}->get_all_by_prop('type'=>'mac')) {
+            if ($m->prop('Address') eq $mk && $m->prop('Zone') ne '') {
+                # translate zone name for Shorewall syntax
+                my %zones = $self->listZones();
+                my $z = $zones{$m->prop('Zone')};
+                return $z.':'.$value;
+            }
+        }
     }
 
     # host group or not: always pick the first element:
@@ -920,6 +940,18 @@ sub _getIpRangeAddress($)
     my $start = $record->prop('Start') || return '';
     my $end = $record->prop('End') || return '';
     return $start.'-'.$end;
+}
+
+sub _getMacAddress($)
+{
+    my $self = shift;
+    my $key = shift;
+
+    my $record = $self->{'mdb'}->get($key) || return '';
+    my $address = $record->prop('Address') || return '';
+    $address = lc($address);
+    $address =~ s/:/-/g;
+    return '~'.$address;
 }
 
 =head2 countReferences(db, key)

--- a/NethServer/Firewall.pm
+++ b/NethServer/Firewall.pm
@@ -983,9 +983,10 @@ sub countReferences($$)
 	'vlan' => 'role',
 	'alias' => 'role',
 	'bond' => 'role',
-        'cidr', => 'cidr',
-        'time', => 'time',
-        'iprange' => 'iprange'
+    'cidr', => 'cidr',
+    'time', => 'time',
+    'iprange' => 'iprange',
+    'mac' => 'mac'
 	};
 
     my $db = esmith::DB::db->open_ro($dbName);

--- a/README.rst
+++ b/README.rst
@@ -164,8 +164,8 @@ Each rule record has the following fields:
 * ``Src``, ``Dst``: {*literal*|*reference*} where
 
   * *literal* is an IP, a CIDR, ``any`` (any source/destination) or ``fw`` (the firewall itself)
-  * *reference* has the form ``prefix;value``, where prefix can be a DB type (``host``, ``host-group``,  ``zone``, ``iprange``, ``cidr``) or the string ``role``, 
-    ``value`` is a DB key or an interface role name (``green``, ``red``...)
+  * *reference* has the form ``prefix;value``, where prefix can be a DB type (``host``, ``host-group``,  ``zone``, ``iprange``, ``cidr``, ``mac``) or the string ``role``, 
+    ``value`` is a DB key or an interface role name (``green``, ``red``...).  ``mac`` objects are *not* supported inside the ``Dst`` field.
 * ``Action``: can be ``ACCEPT``, ``DROP`` or ``REJECT``
 
   * ``ACCEPT`` allows the traffic
@@ -262,6 +262,7 @@ Supported objects are:
 * Ip range
 * Zone
 * Time
+* MAC address
 
 A host is an already defined entry inside the ``hosts`` db, or a new key of type ``host``: ::
 
@@ -320,6 +321,14 @@ Database example: ::
 
     db fwtimes setprop officehours WeekDays 'Mon,Tue,Wed,Thu' TimeStart '09:00' TimeStop '18:00'
 
+A MAC address is a ``mac`` record entry inside ``macs`` database.
+The MAC must always have a ``Zone`` property which specifies the network segment where the device is connected.
+It's something like: ::
+
+ mac1=mac
+    Address=52:54:00:05:2d:c3
+    Description=My mac test
+    Zone=green
 
 
 Rules based on mac address

--- a/api/objects/create
+++ b/api/objects/create
@@ -71,6 +71,10 @@ case $action in
         save_db hosts
         /sbin/e-smith/db hosts set "$(_get name)" host-group Members "$(_get_array Members)" Description "$(_get Description)"
         ;;
+    "create-mac"|"update-mac")
+        save_db macs
+        /sbin/e-smith/db macs set "$(_get name)" mac Zone "$(_get Zone)" Address "$(_get Address)" Description "$(_get Description)"
+        ;;
     *)
         error
         ;;

--- a/api/objects/delete
+++ b/api/objects/delete
@@ -43,6 +43,10 @@ case $action in
         save_db fwtimes
         /sbin/e-smith/db fwtimes delete "$(_get name)"
         ;;
+    "delete-mac")
+        save_db fwtimes
+        /sbin/e-smith/db macs delete "$(_get name)"
+        ;;
     *)
         error
         ;;

--- a/api/objects/read
+++ b/api/objects/read
@@ -181,6 +181,18 @@ if($cmd eq 'hosts' || $cmd eq 'cidr-subs'  || $cmd eq 'host-groups' || $cmd eq '
 
     print encode_json({"local-services" => \@services});
 
+} elsif ($cmd eq 'macs') {
+
+    my $db = esmith::ConfigDB->open_ro('macs');
+    my @macs;
+    foreach ($db->get_all_by_prop('type' => 'mac')) {
+        my %m = $_->props;
+        $m{'name'} = $_->key;
+            push(@macs, \%m);
+    }
+
+    print encode_json({"macs" => \@macs});
+
 } else {
     error()
 }

--- a/api/objects/validate
+++ b/api/objects/validate
@@ -263,6 +263,45 @@ case "delete-host-group":
         }
     }
     break;
+
+case "create-mac":
+case "update-mac":
+    $db = new EsmithDatabase('macs');
+    $ndb = new EsmithDatabase('networks');
+    $zones = array();
+    foreach ($ndb->getAll() as $k => $props) {
+        if (isset($props['role']) && $props['type'] != 'xdsl-disabled') {
+            $zones[$props['role']] = 1;
+        } else if ($props['type'] == 'zone') {
+            $zones[$k] = 1;
+        }
+    }
+
+    $zoneValidator = $v->createValidator()->memberOf(array_keys($zones));
+
+    $v->declareParameter('name', Validate::USERNAME);
+    $v->declareParameter('Description', Validate::ANYTHING);
+    $v->declareParameter('Address', Validate::MACADDRESS);
+    $v->declareParameter('Zone', $zoneValidator);
+
+    if( $action == 'create-mac' && $db->getKey($data['name']) ) {
+        $v->addValidationError('name', 'mac_exists', $data['name']);
+    } elseif ( $action == 'update-mac' && !$db->getKey($data['name']) ){
+        $v->addValidationError('name', 'mac_not_exists', $data['name']);
+    }
+    break;
+case "delete-mac":
+    $db = new EsmithDatabase('macs');
+    if ( !$db->getKey($data['name']) ){
+        $v->addValidationError('name', 'mac_not_exists', $data['name']);
+    } else {
+        $deleteValidator = $v->createValidator()->platform('fwobject-mac-delete', 'macs');
+        if( !$deleteValidator->evaluate($data['name']) ) {
+            $v->addValidationError('name', 'mac_cannot_be_delete', $data['name']);
+        }
+    }
+    break;
+
 default:
     error();
     break;

--- a/api/objects/validate
+++ b/api/objects/validate
@@ -269,6 +269,7 @@ case "update-mac":
     $db = new EsmithDatabase('macs');
     $ndb = new EsmithDatabase('networks');
     $zones = array();
+    $zones['red'] = 1; # always include red role
     foreach ($ndb->getAll() as $k => $props) {
         if (isset($props['role']) && $props['type'] != 'xdsl-disabled') {
             $zones[$props['role']] = 1;
@@ -284,16 +285,17 @@ case "update-mac":
     $v->declareParameter('Address', Validate::MACADDRESS);
     $v->declareParameter('Zone', $zoneValidator);
 
-    if( $action == 'create-mac') {
-        if ( $db->getKey($data['name']) ) {
-            $v->addValidationError('name', 'mac_exists', $data['name']);
-        }
+    # check MAC address does not already exist, excluding current MAC object
+    $exclude = $db->getKey($data['name']);
 
-        foreach ($db->getAll() as $i => $n) {
-            if ($n['Address'] == $data['Address']) {
-                $v->addValidationError('Address', 'mac_address_exists', $data['Address']);
-            }
+    foreach ($db->getAll() as $i => $n) {
+        if ($n['Address'] == $data['Address'] && $i != $exclude) {
+            $v->addValidationError('Address', 'mac_address_exists', $data['Address']);
         }
+    }
+
+    if( $action == 'create-mac' && $db->getKey($data['name']) ) {
+        $v->addValidationError('name', 'mac_exists', $data['name']);
     } elseif ( $action == 'update-mac' && !$db->getKey($data['name']) ){
         $v->addValidationError('name', 'mac_not_exists', $data['name']);
     }

--- a/api/objects/validate
+++ b/api/objects/validate
@@ -284,8 +284,16 @@ case "update-mac":
     $v->declareParameter('Address', Validate::MACADDRESS);
     $v->declareParameter('Zone', $zoneValidator);
 
-    if( $action == 'create-mac' && $db->getKey($data['name']) ) {
-        $v->addValidationError('name', 'mac_exists', $data['name']);
+    if( $action == 'create-mac') {
+        if ( $db->getKey($data['name']) ) {
+            $v->addValidationError('name', 'mac_exists', $data['name']);
+        }
+
+        foreach ($db->getAll() as $i => $n) {
+            if ($n['Address'] == $data['Address']) {
+                $v->addValidationError('Address', 'mac_address_exists', $data['Address']);
+            }
+        }
     } elseif ( $action == 'update-mac' && !$db->getKey($data['name']) ){
         $v->addValidationError('name', 'mac_not_exists', $data['name']);
     }

--- a/createlinks
+++ b/createlinks
@@ -128,6 +128,7 @@ validator_actions($_, qw(
    fwobject-iprange-delete
    fwobject-provider-delete
    fwobject-time-delete
+   fwobject-mac-delete
 ));
 
 validator_actions('fwobject-zone-delete', qw(

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -321,7 +321,18 @@
         "application": "Application",
         "raw": "RAW value, no object found",
         "local": "DNS",
-        "remote": "DHCP"
+        "remote": "DHCP",
+        "add_mac_address": "Add MAC address",
+        "mac_addresses": "MAC addresses",
+        "mac_address": "MAC address",
+        "edit_mac_address": "Edit MAC address",
+        "mac_address_created_ok": "MAC address created successfully!",
+        "mac_address_created_error": "MAC address not created.",
+        "mac_address_updated_ok": "MAC address updated successfully!",
+        "mac_address_updated_error": "MAC address not updated.",
+        "mac_address_deleted_ok": "MAC address deleted successfully!",
+        "mac_address_deleted_error": "MAC address not deleted.",
+        "delete_mac_address": "Delete MAC address"
     },
     "port_forward": {
         "title": "Port Forward",
@@ -501,6 +512,7 @@
         "rule_not_exists": "Rule does not exist",
         "valid_ip_or_cidr": "Must be a valid ip or cidr",
         "time_not_found": "Time object does not exist",
+        "host_key_exists": "A host with the same name already exists",
         "host_doesnt_exists": "Host does not exist",
         "non_existing_port-forward": "Port forward does not exist",
         "non_existing_host": "Host does not exist",
@@ -539,7 +551,12 @@
         "access_invalid": "Invalid access attribute",
         "port_list_empty": "This attribute is mandatory",
         "port_list_invalid": "Invalid list of ports",
-        "tcp_ports_and_udp_ports_empty": "At least one TCP or UDP port must be specified"
+        "tcp_ports_and_udp_ports_empty": "At least one TCP or UDP port must be specified",
+        "mac_exists": "A MAC address with the same name already exists",
+        "mac_not_exists": "MAC address does not exist",
+        "mac_address_exists": "A MAC address with the same address already exists",
+        "valid_macAddress": "Invalid MAC address",
+        "mac_cannot_be_delete": "This MAC address can't be deleted because it is in use"
     },
     "docs": {
         "pf_origin_port": "Insert a single port, a list of comma-separated ports, or a port range using \":\" as separator like \"100:200\".",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -322,6 +322,7 @@
         "raw": "RAW value, no object found",
         "local": "DNS",
         "remote": "DHCP",
+        "mac": "MAC address",
         "add_mac_address": "Add MAC address",
         "mac_addresses": "MAC addresses",
         "mac_address": "MAC address",
@@ -556,7 +557,8 @@
         "mac_not_exists": "MAC address does not exist",
         "mac_address_exists": "A MAC address with the same address already exists",
         "valid_macAddress": "Invalid MAC address",
-        "mac_cannot_be_delete": "This MAC address can't be deleted because it is in use"
+        "mac_cannot_be_delete": "This MAC address can't be deleted because it is in use",
+        "must_be_one_of": "Must be one of"
     },
     "docs": {
         "pf_origin_port": "Insert a single port, a list of comma-separated ports, or a port range using \":\" as separator like \"100:200\".",

--- a/ui/src/views/Objects.vue
+++ b/ui/src/views/Objects.vue
@@ -1854,7 +1854,7 @@ export default {
         },
         {
           label: this.$i18n.t("objects.zone"),
-          field: "Zone",
+          field: "Zone.name",
           filterable: true
         },
         {

--- a/ui/src/views/Objects.vue
+++ b/ui/src/views/Objects.vue
@@ -59,6 +59,14 @@
           id="services-tab-parent"
         >{{$t('objects.services')}}</a>
       </li>
+      <li>
+        <a
+          class="nav-link"
+          data-toggle="tab"
+          href="#mac-addresses-tab"
+          id="mac-addresses-tab-parent"
+        >{{$t('objects.mac_addresses')}}</a>
+      </li>
     </ul>
 
     <div class="tab-content" id="objectsTabContent">
@@ -555,6 +563,72 @@
         </vue-good-table>
       </div>
       <!-- END SERVICES -->
+      <!-- MAC ADDRESSES -->
+      <div class="tab-pane fade active" id="mac-addresses-tab" role="tabpanel" aria-labelledby="mac-addresses-tab">
+        <h3>{{$t('actions')}}</h3>
+        <button @click="openCreateMacAddress()" class="btn btn-primary btn-lg">{{$t('objects.add_mac_address')}}</button>
+
+        <h3>{{$t('list')}}</h3>
+        <div v-if="!view.macAddresses.isLoaded" class="spinner spinner-lg"></div>
+        <vue-good-table
+          v-show="view.macAddresses.isLoaded"
+          :customRowsPerPageDropdown="[25,50,100]"
+          :perPage="25"
+          :columns="macAddressesColumns"
+          :rows="macAddresses"
+          :lineNumbers="false"
+          :defaultSortBy="{field: 'name', type: 'asc'}"
+          :globalSearch="true"
+          :paginate="true"
+          styleClass="table"
+          :nextText="tableLangsTexts.nextText"
+          :prevText="tableLangsTexts.prevText"
+          :rowsPerPageText="tableLangsTexts.rowsPerPageText"
+          :globalSearchPlaceholder="tableLangsTexts.globalSearchPlaceholder"
+          :ofText="tableLangsTexts.ofText"
+        >
+          <template slot="table-row" slot-scope="props">
+            <td class="fancy">
+              <a @click="openEditMacAddress(props.row)">
+                <strong>{{ props.row.name}}</strong>
+              </a>
+            </td>
+            <td class="fancy">{{ props.row.Address}}</td>
+            <td class="fancy">{{ props.row.Description}}</td>
+            <td class="fancy">
+              <span :class="['label', 'label-info', mapBgColor(props.row.Zone.name)]">
+                {{ props.row.Zone.name}}
+              </span>
+            </td>
+            <td>
+              <button @click="openEditMacAddress(props.row)" class="btn btn-default">
+                <span class="fa fa-pencil span-right-margin"></span>
+                {{$t('edit')}}
+              </button>
+              <div class="dropup pull-right dropdown-kebab-pf">
+                <button
+                  class="btn btn-link dropdown-toggle"
+                  type="button"
+                  data-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="true"
+                >
+                  <span class="fa fa-ellipsis-v"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                  <li>
+                    <a @click="openDeleteMacAddress(props.row)">
+                      <span class="fa fa-times span-right-margin"></span>
+                      {{$t('delete')}}
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </td>
+          </template>
+        </vue-good-table>
+      </div>
+      <!-- END MAC ADDRESSES -->
     </div>
 
     <!-- CREATE MODALS -->
@@ -1175,6 +1249,109 @@
         </div>
       </div>
     </div>
+    <div class="modal" id="newMacAddressModal" tabindex="-1" role="dialog" data-backdrop="static">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4
+              class="modal-title"
+            >{{newMacAddress.isEdit ? $t('objects.edit_mac_address') + ' '+ newMacAddress.name : $t('objects.add_mac_address')}}</h4>
+          </div>
+          <form class="form-horizontal" v-on:submit.prevent="saveMacAddress(newMacAddress)">
+            <div class="modal-body">
+              <div :class="['form-group', newMacAddress.errors.name.hasError ? 'has-error' : '']">
+                <label
+                  class="col-sm-3 control-label"
+                >{{$t('objects.name')}}</label>
+                <div class="col-sm-9">
+                  <input
+                    :disabled="newMacAddress.isEdit"
+                    required
+                    type="text"
+                    v-model="newMacAddress.name"
+                    class="form-control"
+                  />
+                  <span
+                    v-if="newMacAddress.errors.name.hasError"
+                    class="help-block"
+                  >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.name.message)}}</span>
+                </div>
+              </div>
+              <div :class="['form-group', newMacAddress.errors.Address.hasError ? 'has-error' : '']">
+                <label
+                  class="col-sm-3 control-label"
+                >{{$t('objects.mac_address')}}</label>
+                <div class="col-sm-9">
+                  <input
+                    required
+                    type="text"
+                    v-model="newMacAddress.Address"
+                    class="form-control"
+                  />
+                  <span
+                    v-if="newMacAddress.errors.Address.hasError"
+                    class="help-block"
+                  >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.Address.message)}}</span>
+                </div>
+              </div>
+              <div
+                :class="['form-group', newMacAddress.errors.Description.hasError ? 'has-error' : '']"
+              >
+                <label
+                  class="col-sm-3 control-label"
+                >{{$t('objects.description')}}</label>
+                <div class="col-sm-9">
+                  <input type="text" v-model="newMacAddress.Description" class="form-control" />
+                  <span
+                    v-if="newMacAddress.errors.Description.hasError"
+                    class="help-block"
+                  >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.Description.message)}}</span>
+                </div>
+              </div>
+              <div :class="['form-group', newMacAddress.errors.Zone.hasError ? 'has-error' : '']">
+                <label class="col-sm-3 control-label">
+                  {{$t('objects.zone')}}
+                </label>
+                <div class="col-sm-9">
+                  <suggestions
+                    v-model="newMacAddress.Zone.name"
+                    required
+                    :options="autoOptions"
+                    :onInputChange="filterAccessZoneAuto"
+                    :onItemSelected="selectAccessZoneAuto"
+                  >
+                    <div slot="item" slot-scope="props" class="single-item">
+                      <span>
+                        <span
+                          v-show="props.item.typeId == 'role'"
+                          :class="['square-'+ props.item.name.toUpperCase()]"
+                        ></span>
+                        {{props.item.name}}
+                        <i class="mg-left-5">{{props.item.Description}}</i>
+                        <b class="mg-left-5">{{props.item.type | capitalize}}</b>
+                      </span>
+                    </div>
+                  </suggestions>
+                  <span
+                    v-if="newMacAddress.Zone.type && newMacAddress.Zone.type.length > 0"
+                    class="help-block gray"
+                  >{{newMacAddress.Zone.typeFull}}</span>
+                  <span
+                    v-if="newMacAddress.errors.Zone.hasError"
+                    class="help-block"
+                  >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.Zone.message)}}</span>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <div v-if="newMacAddress.isLoading" class="spinner spinner-sm form-spinner-loader"></div>
+              <button class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
+              <button class="btn btn-primary" type="submit">{{$t('save')}}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
     <!-- END CREATE MODALS -->
     <!-- DELETE MODALS -->
     <div class="modal" id="deleteHostModal" tabindex="-1" role="dialog" data-backdrop="static">
@@ -1397,6 +1574,34 @@
         </div>
       </div>
     </div>
+    <div class="modal" id="deleteMacAddressModal" tabindex="-1" role="dialog" data-backdrop="static">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title">{{$t('objects.delete_mac_address')}} {{currentMacAddress.name}}</h4>
+          </div>
+          <form class="form-horizontal" v-on:submit.prevent="deleteMacAddress(currentMacAddress)">
+            <div class="modal-body">
+              <div v-show="currentMacAddress.isError" class="alert alert-warning alert-dismissable">
+                <span class="pficon pficon-warning-triangle-o"></span>
+                <strong>{{$t('warning')}}.</strong>
+                {{$t('validation.'+currentMacAddress.isError)}}.
+              </div>
+              <div class="form-group">
+                <label
+                  class="col-sm-3 control-label"
+                >{{$t('are_you_sure')}}?</label>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <div v-if="currentMacAddress.isLoading" class="spinner spinner-sm form-spinner-loader"></div>
+              <button class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
+              <button class="btn btn-danger" type="submit">{{$t('delete')}}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
     <!-- DELETE END MODALS -->
   </div>
 </template>
@@ -1456,7 +1661,10 @@ export default {
         },
         services: {
           isLoaded: false
-        }
+        },
+        macAddresses: {
+          isLoaded: false
+        },
       },
       tableLangsTexts: this.tableLangs(),
       hostsColumns: [
@@ -1628,6 +1836,34 @@ export default {
           sortable: false
         }
       ],
+      macAddressesColumns: [
+        {
+          label: this.$i18n.t("objects.name"),
+          field: "name",
+          filterable: true
+        },
+        {
+          label: this.$i18n.t("objects.mac_address"),
+          field: "Address",
+          filterable: true
+        },
+        {
+          label: this.$i18n.t("objects.description"),
+          field: "Description",
+          filterable: true
+        },
+        {
+          label: this.$i18n.t("objects.zone"),
+          field: "Zone",
+          filterable: true
+        },
+        {
+          label: this.$i18n.t("action"),
+          field: "",
+          filterable: true,
+          sortable: false
+        }
+      ],
       hostsRows: [],
       hostGroupsRows: [],
       ipRangesRows: [],
@@ -1635,6 +1871,7 @@ export default {
       zonesRows: [],
       timeConditionsRows: [],
       servicesRows: [],
+      macAddresses: [],
       currentHost: {},
       newHost: this.initHost(),
       currentHostGroup: {},
@@ -1649,6 +1886,12 @@ export default {
       newTimeCondition: this.initTimeCondition(),
       currentService: {},
       newService: this.initService(),
+      currentMacAddress: {},
+      newMacAddress: this.initMacAddress(),
+      autoOptions: {
+        inputClass: "form-control"
+      },
+      accessZones: [],
       protocols: [],
       interfaces: [],
       weekdays: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -1763,6 +2006,24 @@ export default {
         Ports: "",
         Description: "",
         errors: this.initServiceErrors()
+      };
+    },
+    initMacAddress() {
+      return {
+        isLoading: false,
+        isEdit: false,
+        isError: false,
+        name: "",
+        Address: "",
+        Description: "",
+        Zone: {
+          name: "",
+          Description: "",
+          typeId: "",
+          type: "",
+          typeFull: "",
+        },
+        errors: this.initMacAddressErrors()
       };
     },
     initHostErrors() {
@@ -1895,6 +2156,26 @@ export default {
           hasError: false,
           message: ""
         }
+      };
+    },
+    initMacAddressErrors() {
+      return {
+        name: {
+          hasError: false,
+          message: ""
+        },
+        Address: {
+          hasError: false,
+          message: ""
+        },
+        Description: {
+          hasError: false,
+          message: ""
+        },
+        Zone: {
+          hasError: false,
+          message: ""
+        },
       };
     },
     getInterfaces() {
@@ -2071,6 +2352,7 @@ export default {
           }
           context.view.zones.isLoaded = true;
           context.zonesRows = success["zones"];
+          context.getRoles();
 
           context.$forceUpdate();
           context.$parent.getFirewallStatus();
@@ -2125,6 +2407,41 @@ export default {
           }
           context.view.services.isLoaded = true;
           context.servicesRows = success["services"];
+
+          context.$forceUpdate();
+          context.$parent.getFirewallStatus();
+        },
+        function(error) {
+          console.error(error);
+        }
+      );
+    },
+    getMacAddresses() {
+      var context = this;
+
+      context.view.macAddresses.isLoaded = false;
+      nethserver.exec(
+        ["nethserver-firewall-base/objects/read"],
+        {
+          action: "macs"
+        },
+        null,
+        function(success) {
+          try {
+            success = JSON.parse(success);
+          } catch (e) {
+            console.error(e);
+          }
+          context.view.macAddresses.isLoaded = true;
+          var macAddresses = success["macs"];
+          context.macAddresses = macAddresses.map(function(mac) {
+            var accessZoneName = mac.Zone;
+            var accessZone = context.accessZones.find(function(elem) {
+              return elem.name === accessZoneName;
+            });
+            mac.Zone = accessZone;
+            return mac;
+          });
 
           context.$forceUpdate();
           context.$parent.getFirewallStatus();
@@ -3187,6 +3504,243 @@ export default {
           }
         }
       );
+    },
+    openCreateMacAddress() {
+      this.newMacAddress = this.initMacAddress();
+      $("#newMacAddressModal").modal("show");
+    },
+    openEditMacAddress(macAddress) {
+      this.newMacAddress = Object.assign({}, macAddress);
+      this.newMacAddress.errors = this.initMacAddressErrors();
+      this.newMacAddress.isLoading = false;
+      this.newMacAddress.isEdit = true;
+
+      this.newMacAddress.Zone.typeFull =
+        macAddress.Zone.name +
+        " " +
+        (macAddress.Zone.Interface ? macAddress.Zone.Interface + " " : "") +
+        (macAddress.Zone.Network ? macAddress.Zone.Network + " " : "") +
+        "(" +
+        this.$i18n.t("objects." + macAddress.Zone.typeId) +
+        ")";
+      $("#newMacAddressModal").modal("show");
+    },
+    saveMacAddress(macAddress) {
+      var context = this;
+
+      var macAddressObj = Object.assign({}, macAddress);
+      delete macAddressObj.isLoading;
+      delete macAddressObj.isEdit;
+      delete macAddressObj.isError;
+      delete macAddressObj.errors;
+      macAddressObj.Zone = macAddressObj.Zone.name;
+      macAddressObj.action = macAddress.isEdit ? "update-mac" : "create-mac";
+
+      context.newMacAddress.isLoading = true;
+      nethserver.exec(
+        ["nethserver-firewall-base/objects/validate"],
+        macAddressObj,
+        null,
+        function(success) {
+          context.newMacAddress.isLoading = false;
+          $("#newMacAddressModal").modal("hide");
+
+          // notification
+          nethserver.notifications.success = context.$i18n.t(
+            "objects.mac_address_" +
+              (context.newMacAddress.isEdit ? "updated" : "created") +
+              "_ok"
+          );
+          nethserver.notifications.error = context.$i18n.t(
+            "objects.mac_address_" +
+              (context.newMacAddress.isEdit ? "updated" : "created") +
+              "_error"
+          );
+
+          // update values
+          if (macAddress.isEdit) {
+            nethserver.exec(
+              ["nethserver-firewall-base/objects/update"],
+              macAddressObj,
+              function(stream) {
+                console.info("macAddresses", stream);
+              },
+              function(success) {
+                // get mac addresses
+                context.getMacAddresses();
+              },
+              function(error, data) {
+                console.error(error, data);
+              }
+            );
+          } else {
+            nethserver.exec(
+              ["nethserver-firewall-base/objects/create"],
+              macAddressObj,
+              function(stream) {
+                console.info("macAddresses", stream);
+              },
+              function(success) {
+                // get mac addresses
+                context.getMacAddresses();
+              },
+              function(error, data) {
+                console.error(error, data);
+              }
+            );
+          }
+        },
+        function(error, data) {
+          var errorData = {};
+          context.newMacAddress.isLoading = false;
+          context.newMacAddress.errors = context.initMacAddressErrors();
+
+          try {
+            errorData = JSON.parse(data);
+            for (var e in errorData.attributes) {
+              var attr = errorData.attributes[e];
+              context.newMacAddress.errors[attr.parameter].hasError = true;
+              context.newMacAddress.errors[attr.parameter].message = attr.error;
+            }
+            context.$forceUpdate();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      );
+    },
+    openDeleteMacAddress(macAddress) {
+      this.currentMacAddress = Object.assign({}, macAddress);
+      $("#deleteMacAddressModal").modal("show");
+    },
+    deleteMacAddress(macAddress) {
+      var context = this;
+
+      // notification
+      nethserver.notifications.success = context.$i18n.t(
+        "objects.mac_address_deleted_ok"
+      );
+      nethserver.notifications.error = context.$i18n.t(
+        "objects.mac_address_deleted_error"
+      );
+
+      nethserver.exec(
+        ["nethserver-firewall-base/objects/validate"],
+        {
+          name: macAddress.name,
+          action: "delete-mac"
+        },
+        null,
+        function(success) {
+          $("#deleteMacAddressModal").modal("hide");
+          nethserver.exec(
+            ["nethserver-firewall-base/objects/delete"],
+            {
+              name: macAddress.name,
+              action: "delete-mac"
+            },
+            function(stream) {
+              console.info("macAddresses", stream);
+            },
+            function(success) {
+              // get mac addresses
+              context.getMacAddresses();
+            },
+            function(error, data) {
+              console.error(error, data);
+            }
+          );
+        },
+        function(error, data) {
+          console.error(error, data);
+          try {
+            var errorData = JSON.parse(data);
+            macAddress.isError = errorData.attributes[0].error;
+            context.$forceUpdate();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      );
+    },
+    getRoles() {
+      var context = this;
+
+      nethserver.exec(
+        ["nethserver-firewall-base/rules/read"],
+        {
+          action: "roles"
+        },
+        null,
+        function(success) {
+          try {
+            success = JSON.parse(success);
+          } catch (e) {
+            console.error(e);
+          }
+          var roles = success.roles;
+          roles = roles.map(function(r) {
+            var i = {};
+            i.name = r;
+            i.Description = r.toUpperCase() + " " + context.$i18n.t("objects.role");
+            i.type = context.$i18n.t("objects.role");
+            i.typeId = "role";
+            return i;
+          });
+
+          var zones = context.zonesRows.map(function(i) {
+            i.type = context.$i18n.t("objects.zone");
+            i.typeId = "zone";
+            return i;
+          });
+          context.accessZones = roles.concat(zones);
+
+          if (!context.view.macAddresses.isLoaded) {
+            context.getMacAddresses();
+          }
+        },
+        function(error) {
+          console.error(error);
+        }
+      );
+    },
+    filterAccessZoneAuto(query) {
+      this.newMacAddress.Zone = {};
+
+      if (query.trim().length === 0) {
+        return null;
+      }
+
+      return this.accessZones.filter(function(item) {
+        return (
+          item.typeId.toLowerCase().includes(query.toLowerCase()) ||
+          item.name.toLowerCase().includes(query.toLowerCase()) ||
+          item.Description.toLowerCase().includes(query.toLowerCase())
+        );
+      });
+    },
+    selectAccessZoneAuto(item) {
+      this.newMacAddress.Zone = item;
+      this.newMacAddress.Zone.typeFull =
+        item.name +
+        " " +
+        (item.Interface ? item.Interface + " " : "") +
+        (item.Network ? item.Network + " " : "") +
+        "(" +
+        this.$i18n.t("objects." + item.typeId) +
+        ")";
+    },
+    mapBgColor(accesZoneName) {
+      switch (accesZoneName) {
+      case "green":
+      case "red":
+      case "orange":
+      case "blue":
+        return "bg-" + accesZoneName;
+        break;
+      default:
+        return "bg-missing";
+      }
     }
   }
 };

--- a/ui/src/views/Objects.vue
+++ b/ui/src/views/Objects.vue
@@ -23,6 +23,14 @@
         <a
           class="nav-link"
           data-toggle="tab"
+          href="#mac-addresses-tab"
+          id="mac-addresses-tab-parent"
+        >{{$t('objects.mac_addresses')}}</a>
+      </li>
+      <li>
+        <a
+          class="nav-link"
+          data-toggle="tab"
           href="#ip-ranges-tab"
           id="ip-ranges-tab-parent"
         >{{$t('objects.ip_ranges')}}</a>
@@ -58,14 +66,6 @@
           href="#services-tab"
           id="services-tab-parent"
         >{{$t('objects.services')}}</a>
-      </li>
-      <li>
-        <a
-          class="nav-link"
-          data-toggle="tab"
-          href="#mac-addresses-tab"
-          id="mac-addresses-tab-parent"
-        >{{$t('objects.mac_addresses')}}</a>
       </li>
     </ul>
 
@@ -1294,20 +1294,6 @@
                   >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.Address.message)}}</span>
                 </div>
               </div>
-              <div
-                :class="['form-group', newMacAddress.errors.Description.hasError ? 'has-error' : '']"
-              >
-                <label
-                  class="col-sm-3 control-label"
-                >{{$t('objects.description')}}</label>
-                <div class="col-sm-9">
-                  <input type="text" v-model="newMacAddress.Description" class="form-control" />
-                  <span
-                    v-if="newMacAddress.errors.Description.hasError"
-                    class="help-block"
-                  >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.Description.message)}}</span>
-                </div>
-              </div>
               <div :class="['form-group', newMacAddress.errors.Zone.hasError ? 'has-error' : '']">
                 <label class="col-sm-3 control-label">
                   {{$t('objects.zone')}}
@@ -1339,7 +1325,21 @@
                   <span
                     v-if="newMacAddress.errors.Zone.hasError"
                     class="help-block"
-                  >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.Zone.message)}}</span>
+                  >{{$t('validation.validation_failed')}}: {{$t('validation.must_be_one_of') + " " + accessZonesList}} </span>
+                </div>
+              </div>
+              <div
+                :class="['form-group', newMacAddress.errors.Description.hasError ? 'has-error' : '']"
+              >
+                <label
+                  class="col-sm-3 control-label"
+                >{{$t('objects.description')}}</label>
+                <div class="col-sm-9">
+                  <input type="text" v-model="newMacAddress.Description" class="form-control" />
+                  <span
+                    v-if="newMacAddress.errors.Description.hasError"
+                    class="help-block"
+                  >{{$t('validation.validation_failed')}}: {{$t('validation.'+newMacAddress.errors.Description.message)}}</span>
                 </div>
               </div>
             </div>
@@ -1896,6 +1896,13 @@ export default {
       interfaces: [],
       weekdays: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     };
+  },
+  computed: {
+    accessZonesList() {
+      return this.accessZones.map(function(accessZone) {
+        return accessZone.name;
+      }).join(", ");
+    }
   },
   methods: {
     hostAlreadyAdded(bind) {


### PR DESCRIPTION
This PR adds 2 features:
- allow creation of firewall rules using MAC address objects
- allow creation of firewall rules which apply also on established and related connections


## MAC objects

- Create a MAC object:
```
db macs set m1 mac Address '52:54:00:05:2d:c3' Description 'test' Zone green
```
- Create a rule using an host object from the web interface, then modify it from command line:
```
db fwrules setprop 1 Src 'mac;m1'
```
- Apply the configuration:
```
signal-event firewall-adjust
```


## Modifications needed for the UI

- firewall object page: CRUD operations for MAC address objects
- rules page: allow the selection of MAC objects inside the source field

Validation rules:
- rules: a MAC object can't be used as destination
- object: Address and Zone property are mandatory

NethServer/dev#6269