### PR TITLE
rules: add connection state support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,10 @@ Each rule record has the following fields:
 * ``Time``: (optional) can be a time object, the rule will be enabled only if the time conditions is matched
 * ``Log``: can be ``none`` or ``info``. If value is ``info``, all matched packets will be logged in ``/var/log/firewall.log``. Defaults to ``none``
 * ``status``: can be ``enabled`` or ``disabled``. Default is ``enabled``
+* ``State``: (optional) select on which type of connection the rule will be applied to:
+
+  * ``new`` or empty: default, the rule will be applied only to new connections
+  * ``all``: the rule will be applied to new and established/related connections
 * ``Description``: (optional)
 
 Example of a rule accepting traffic: ::

--- a/api/lib/firewall_functions
+++ b/api/lib/firewall_functions
@@ -271,7 +271,7 @@ function fw_rule
         Position "$(_get Position)"  Time "$Time" \
         Dst "$Dst" Service "$Service" \
         Src "$Src" status "$(_get status)" \
-        Description "$(_get Description)"
+        State "$(_get State)" Description "$(_get Description)"
     
     if [ $? -gt 0 ]; then
         error "SaveFailed" "check_logs"

--- a/api/lib/firewall_functions.php
+++ b/api/lib/firewall_functions.php
@@ -148,6 +148,10 @@ function validate_rule($data, $type) {
         }
     }
 
+    if ($data['State']) {
+        $v->declareParameter('State', $v->createValidator()->memberOf('all', 'new'));
+    }
+
     # Validate the input
     if ($v->validate()) {
         success();

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base15rules
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base15rules
@@ -1,5 +1,5 @@
 #
-# 60rules
+# 10base15rules
 #
 {
     use NethServer::Firewall;
@@ -9,8 +9,8 @@
         my $status = $rule->prop("status") || "disabled";
         my $state = $rule->prop("State") || "new";
         next unless ($status eq 'enabled');
-        next if ($state ne "new");
-
+        next if ($state ne "all");
+ 
         my $src = $rule->prop("Src") || next; 
         my $dst = $rule->prop("Dst") || next;
         my $action = $rule->prop("Action") || next;
@@ -34,8 +34,8 @@
         $action .= ":$log" unless ($log eq '');
 
         # Replace empty values with "-", for column count consistency:
-        $src_addr = $src_addr eq '' ? '-' : $src_addr;
-        $dst_addr = $dst_addr eq '' ? '-' : $dst_addr;
+	    $src_addr = $src_addr eq '' ? '-' : $src_addr;
+	    $dst_addr = $dst_addr eq '' ? '-' : $dst_addr;
 
         my $params = {
             'action' => $action,

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -400,8 +400,10 @@
         "reject": "Reject",
         "drop": "Drop",
         "log": "Log",
+        "state_enabled": "This rule is applied to new, established and related connections",
         "quick_rule": "Quick rule (acts immediately on every connection)",
         "log_enabled": "Log enabled",
+        "state": "Apply to existing connections",
         "duplicate": "Duplicate",
         "expand": "Expand info",
         "to_firewall": "To Firewall",
@@ -563,6 +565,7 @@
     "docs": {
         "pf_origin_port": "Insert a single port, a list of comma-separated ports, or a port range using \":\" as separator like \"100:200\".",
         "rules_source": "You may insert an IP address or a CIDR if you do not want to create a host or CIDR object.",
+        "rules_state": "As default, rules are applied only to new connections. When this option is enabled, the rule will be applied to all connections including already established ones.",
         "rules_destination": "You may insert an IP address or a CIDR if you do not want to create a host or CIDR object.",
         "objects_ports": "Supported syntax: comma-separated port list or port range (i.e. 10000-20000)",
         "mac_validation": "Requests from IP addresses listed in DHCP reservations are allowed only if are originated from the associated MAC address (even if DHCP is disabled).",

--- a/ui/src/views/Rules.vue
+++ b/ui/src/views/Rules.vue
@@ -753,7 +753,13 @@ export default {
       highlightInstance: null,
       expandInfo: true,
       status: {},
-      newObject: this.initObject()
+      newObject: this.initObject(),
+      any: {
+        name: "any",
+        type: "any",
+        typeId: "any",
+        Description: ""
+      }
     };
   },
   computed: {
@@ -1276,7 +1282,7 @@ export default {
       var objects = this.roles.concat(
         this.hosts.concat(
           this.hostGroups.concat(
-            this.ipRanges.concat(this.cidrSubs.concat(this.zones.concat(this.macAddresses)))
+            this.ipRanges.concat(this.cidrSubs.concat(this.zones.concat(this.macAddresses.concat(this.any))))
           )
         )
       );
@@ -1321,7 +1327,7 @@ export default {
       var objects = this.roles.concat(
         this.hosts.concat(
           this.hostGroups.concat(
-            this.ipRanges.concat(this.cidrSubs.concat(this.zones))
+            this.ipRanges.concat(this.cidrSubs.concat(this.zones.concat(this.any)))
           )
         )
       );

--- a/ui/src/views/Rules.vue
+++ b/ui/src/views/Rules.vue
@@ -128,6 +128,14 @@
                 v-show="r.Log"
                 class="fa fa-bookmark-o log-icon"
               ></span>
+              <span
+                data-toggle="tooltip"
+                data-placement="top"
+                data-html="true"
+                :title="$t('rules.state_enabled')"
+                v-show="r.State"
+                class="pficon pficon-security pf-orange state-icon"
+              ></span>
             </div>
             <div class="list-view-pf-body">
               <div class="list-view-pf-description rules-src-dst">
@@ -537,6 +545,29 @@
                   </span>
                 </div>
               </div>
+
+              <div
+                v-show="newRule.advanced"
+                :class="['form-group', newRule.errors.State.hasError ? 'has-error' : '']"
+              >
+                <label class="col-sm-3 control-label">
+                  {{$t('rules.state')}}
+                  <doc-info
+                    :placement="'top'"
+                    :title="$t('rules.state_enabled')"
+                    :chapter="'rules_state'"
+                    :inline="true"
+                  ></doc-info>
+                </label>
+                <div class="col-sm-9">
+                  <input class="form-control" type="checkbox" v-model="newRule.State">
+                  <span v-if="newRule.errors.State.hasError" class="help-block">
+                    {{$t('validation.validation_failed')}}:
+                    {{$t('validation.'+newRule.errors.State.message)}}
+                  </span>
+                </div>
+              </div>
+
             </div>
             <div class="modal-footer no-mg-top">
               <div v-if="newRule.isLoading" class="spinner spinner-sm form-spinner-loader"></div>
@@ -789,6 +820,14 @@ export default {
           '<div class="type-info"><span class="fa fa-bookmark-o mg-right-5 mg-top-5 detail-icon"></span>' +
           "<span>" +
           this.$i18n.t("rules.log_enabled") +
+          "</span></div>";
+      }
+
+      if (rule.State) {
+        html +=
+          '<div class="type-info"><span class="pficon pficon-security mg-right-5 mg-top-5 detail-icon"></span>' +
+          "<span>" +
+          this.$i18n.t("rules.state") +
           "</span></div>";
       }
 
@@ -1173,6 +1212,7 @@ export default {
         Quick: false,
         Time: "",
         Description: "",
+        State: false,
         isLoading: false,
         isEdit: false,
         isDuplicate: false,
@@ -1214,7 +1254,7 @@ export default {
           hasError: false,
           message: ""
         },
-        Log: {
+        State: {
           hasError: false,
           message: ""
         },
@@ -1647,6 +1687,7 @@ export default {
             success = JSON.parse(success);
             var rules = success.rules.map(function(r) {
               r.Log = r.Log == "none" ? false : true;
+              r.State = (r.State == "new" || r.State == "" || !r.State) ? false : true;
               return r;
             });
             context.rules = rules;
@@ -1764,6 +1805,7 @@ export default {
         id: r.id,
         Src: r.Src ? r.Src : null,
         Description: r.Description,
+        State: r.State ? "all" : "new",
         type: "rule"
       };
 
@@ -1821,6 +1863,7 @@ export default {
           ? context.newRule.SrcFull
           : { name: context.newRule.Src, type: "raw" },
         type: "rule",
+        State: context.newRule.State ? "all" : "new",
         Description: context.newRule.Description
       };
 
@@ -2252,6 +2295,14 @@ export default {
   bottom: 9px;
   margin-left: -40px;
   font-size: 12px !important;
+}
+
+.state-icon {
+  position: absolute;
+  bottom: 50px;
+  margin-left: -40px;
+  font-size: 12px !important;
+  color: #ec7a08;
 }
 
 .type-info {


### PR DESCRIPTION
A rule can now be placed under the "ALL" or "NEW" section inside the
/etc/shorewall/rules file.

Allow creation of firewall rules which apply also on established and related connections.

The combination of this PR with #151 will permit to quickly block the traffic from an hostile host inside the LAN.

## Rules on all connections
- Create a rule from the web interface, then modify it from command line:
```
db fwrules setprop 1 State all
```
- Apply the configuration:
```
signal-event firewall-adjust
```

## Modifications needed for the UI

- rules page: add a new checkbox inside the advanced section, something like `Apply rule to existing connections`
- rules page: allow the `any` target for source and destination to support traffic blocking from hosts identified only by MAC addresses
- rules page: highlight rules with State all inside the list view

Validation rules:
- the State prop can have a value between `new` and `all`
- `any` can be allowed as Src or Dst

NethServer/dev#6270
