### PR TITLE
Fix validation for MAC address

### DIFF
--- a/api/objects/validate
+++ b/api/objects/validate
@@ -285,11 +285,9 @@ case "update-mac":
     $v->declareParameter('Address', Validate::MACADDRESS);
     $v->declareParameter('Zone', $zoneValidator);
 
-    # check MAC address does not already exist, excluding current MAC object
-    $exclude = $db->getKey($data['name']);
-
     foreach ($db->getAll() as $i => $n) {
-        if ($n['Address'] == $data['Address'] && $i != $exclude) {
+        # check MAC address does not already exist, excluding current MAC object
+        if ($n['Address'] == $data['Address'] && $i != $data['name']) {
             $v->addValidationError('Address', 'mac_address_exists', $data['Address']);
         }
     }


### PR DESCRIPTION
Fix validation for MAC object edit.
Validation ensures that MAC address is not already used by another MAC object

NethServer/dev#6269