### PR TITLE
Fix undefined value to create object in WAN rule

### DIFF
--- a/ui/src/views/WAN.vue
+++ b/ui/src/views/WAN.vue
@@ -457,8 +457,8 @@
                     {{r.Dst.type == 'fw' || r.Dst.type == 'role' || r.Dst.type == 'any' ? (r.Dst.name.toUpperCase()): r.Dst.name}}
                     <a
                       v-show="r.Dst.type == 'raw'"
-                      @click="openCreateObject(r.Src)"
-                    >{{$t('create')}} {{$t('objects.'+r.Src.object)}}</a>
+                      @click="openCreateObject(r.Dst)"
+                    >{{$t('create')}} {{$t('objects.'+r.Dst.object)}}</a>
                   </span>
                 </span>
               </div>


### PR DESCRIPTION
When you create a rule in the WAN firewall application you have an issue about undefined values

see also https://trello.com/c/875GDc41/232-bug-su-wan-e-policy-route

https://github.com/NethServer/dev/issues/6289