### PR TITLE
Firewall: validation of Allow prop in port forward UI

### DIFF
--- a/api/port-forward/validate
+++ b/api/port-forward/validate
@@ -91,9 +91,15 @@ case "create":
 
     $v->declareParameter('OriDst', Validate::IPv4_OR_EMPTY);
     $v->declareParameter('status', Validate::SERVICESTATUS);
-    $v->declareParameter('Allow', Validate::ANYTHING);
     $v->declareParameter('Description', $v->createValidator()->maxLength(35));
     $v->declareParameter('Log', $logValidator);
+
+    $ipValidator = $v->createValidator()->ipV4Address();
+    foreach ( $data['Allow'] as $el) {
+        if (!$ipValidator->evaluate($el) ) {
+            $v->addValidationError('Allow', 'valid_ipV4Address', $el);
+        }
+    }
 
     if (is_array($data['Src'])) {
         foreach ($data['Src'] as $el) {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -545,7 +545,7 @@
         "not_exists_host-group": "The host group does not exist",
         "host_group_cannot_be_delete": "This host group  can't be deleted because it is in use",
         "valid_lessThan_256": "Must be less than 256",
-        "valid_ipV4Address": "Invalid address",
+        "valid_ipV4Address": "Invalid IPv4 address",
         "valid_username": "First character must be a letter, than only lower letters, numbers and symbols like '-' and '_'",
         "valid_notEmpty": "Must be non-empty",
         "valid_cidrBlock": "Must be a valid CIDR network",

--- a/ui/src/views/PortForward.vue
+++ b/ui/src/views/PortForward.vue
@@ -352,7 +352,7 @@
                   <textarea v-model="newPf.Allow" class="form-control textarea-mid-height"></textarea>
                   <span v-if="newPf.errors.Allow.hasError" class="help-block">
                     {{$t('validation.validation_failed')}}:
-                    {{$t('validation.'+newPf.errors.Allow.message)}}
+                    {{$t('validation.'+newPf.errors.Allow.message)}}: '{{newPf.errors.Allow.value}}'
                   </span>
                 </div>
               </div>
@@ -1029,6 +1029,7 @@ export default {
               var attr = errorData.attributes[e];
               context.newPf.errors[attr.parameter].hasError = true;
               context.newPf.errors[attr.parameter].message = attr.error;
+              context.newPf.errors[attr.parameter].value = attr.value;
             }
           } catch (e) {
             console.error(e);


### PR DESCRIPTION
There is no validation about IP for the property Allow, the PR attempts to fix it

cf https://trello.com/c/kug8jVZT/234-bug-indirizzi-ip-con-spazio