### PR TITLE
ui. specific version for vue-good-table

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8920,9 +8920,9 @@
       "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ=="
     },
     "vue-good-table": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/vue-good-table/-/vue-good-table-2.21.0.tgz",
-      "integrity": "sha512-e384AGlmEBG0CfTkZXN/OZe1O58V2mbxQafsKqzVrqvROcMZsa9iSyK11D4YS2JzlJo9mRqsad4/vrV/U/Xbdw==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/vue-good-table/-/vue-good-table-2.21.1.tgz",
+      "integrity": "sha512-pirdVPwo1d4IzQLkDXByD4jvp/l4afo8S/U0ORw1eOWDt6gyvIoEcRz2uw33ZXemMs5NDs79MinbXm9Nhhzr+Q==",
       "requires": {
         "date-fns": "^2.0.0-beta.4",
         "diacriticless": "1.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,7 @@
     "v-suggestions": "^1.1.1",
     "vis": "^4.21.0",
     "vue": "^2.5.17",
-    "vue-good-table": "^2.19.3",
+    "vue-good-table": "2.21.1",
     "vue-i18n": "^8.3.2",
     "vue-js-toggle-button": "^1.3.1",
     "vue-router": "^3.0.1"


### PR DESCRIPTION
Use a specific `vue-good-table` version (2.21.1) in order to have a predictable UI and behavior

NethServer/dev#6390