### PR TITLE
Use any+ instead of any

### DIFF
--- a/NethServer/Firewall.pm
+++ b/NethServer/Firewall.pm
@@ -186,7 +186,7 @@ sub getAddress($)
     my $expand_zone = shift || 0;
 
     if ( lc($id) eq 'any') {
-        return 'any';
+        return 'any+';
     }
 
     if ( lc($id) eq 'fw') {


### PR DESCRIPTION
If `any` is passed to `getAddress()` function in `NethServer/Firewall.pm`, return `any+`