### PR TITLE
ui. fix unit of measurement in bandwidth chart

### DIFF
--- a/ui/src/views/TrafficShaping.vue
+++ b/ui/src/views/TrafficShaping.vue
@@ -1998,7 +1998,8 @@ export default {
                     axes: {
                       y: {
                         axisLabelFormatter: function(y) {
-                          return context.$options.filters.byteFormat(y);
+                          // netdata values are expressed in KB
+                          return context.$options.filters.byteFormat(y * 1024);
                         }
                       }
                     }
@@ -2036,7 +2037,8 @@ export default {
                     axes: {
                       y: {
                         axisLabelFormatter: function(y) {
-                          return context.$options.filters.byteFormat(y);
+                          // netdata values are expressed in KB
+                          return context.$options.filters.byteFormat(y * 1024);
                         }
                       }
                     }


### PR DESCRIPTION
Fix unit of measurement in traffic shaping bandwidth chart; netdata values are expressed in KB

NethServer/dev#6475