### PR TITLE
pppoe: fix plugin option name

### DIFF
--- a/root/etc/e-smith/events/actions/interface-config-write-pppoe
+++ b/root/etc/e-smith/events/actions/interface-config-write-pppoe
@@ -56,7 +56,7 @@ my %defaults = (qw(
 ));
 
 # Configure pppd plugin for high-speed PPPoE connections
-$defaults{'plugin'} =  glob("/usr/lib64/pppd/*/rp-pppoe.so");
+$defaults{'linux_plugin'} =  glob("/usr/lib64/pppd/*/rp-pppoe.so");
 
 my $file = "$output_dir/ifcfg-ppp0";
 my %props = $ndb->get('ppp0') ? $ndb->get('ppp0')->props : ();


### PR DESCRIPTION
The correct option is named LINUX_PLUGIN, see man pppoe.conf.

NethServer/dev#6500