### PR TITLE
Firewall WAN notification for wan link down

### DIFF
--- a/api/wan/read
+++ b/api/wan/read
@@ -77,7 +77,9 @@ if($cmd eq 'providers') {
     foreach (qw(MaxNumberPacketLoss MaxPercentPacketLoss NotifyWan PingInterval WanMode)) {
         $ret->{'configuration'}{'multiwan'}{$_} = $cdb->get_prop('firewall',$_);
     }
-    $ret->{'configuration'}{'multiwan'}{'EmailAddress'} = $cdb->get_prop('root', 'EmailAddress');
+    my $EmailNotifications = $cdb->get_prop('root', 'EmailAddress');
+    $EmailNotifications =~ s/,/ /g;
+    $ret->{'configuration'}{'multiwan'}{'EmailAddress'} = $EmailNotifications;
 	if ($ret->{'configuration'}{'multiwan'}{'WanMode'} eq 'backup') {
 		my $externalip = `dig +short myip.opendns.com \@resolver1.opendns.com`;
 		chomp $externalip;

--- a/api/wan/read
+++ b/api/wan/read
@@ -77,9 +77,20 @@ if($cmd eq 'providers') {
     foreach (qw(MaxNumberPacketLoss MaxPercentPacketLoss NotifyWan PingInterval WanMode)) {
         $ret->{'configuration'}{'multiwan'}{$_} = $cdb->get_prop('firewall',$_);
     }
+    my $NotifyWanTo =  $cdb->get_prop('firewall','NotifyWanTo');
+    $NotifyWanTo  =~ s/,/ /g;
     my $EmailNotifications = $cdb->get_prop('root', 'EmailAddress');
     $EmailNotifications =~ s/,/ /g;
-    $ret->{'configuration'}{'multiwan'}{'EmailAddress'} = $EmailNotifications;
+
+    # default property is NotifyWanTo === root@localhost
+    if ($NotifyWanTo ne "" && $NotifyWanTo ne 'root@localhost') {
+        $ret->{'configuration'}{'multiwan'}{'EmailAddress'} = $NotifyWanTo;
+    } elsif ($EmailNotifications ne '') {
+        $ret->{'configuration'}{'multiwan'}{'EmailAddress'} = $EmailNotifications;
+    } else {
+        $ret->{'configuration'}{'multiwan'}{'EmailAddress'} = 'root@localhost';
+    }
+
 	if ($ret->{'configuration'}{'multiwan'}{'WanMode'} eq 'backup') {
 		my $externalip = `dig +short myip.opendns.com \@resolver1.opendns.com`;
 		chomp $externalip;

--- a/api/wan/update
+++ b/api/wan/update
@@ -47,12 +47,14 @@ case $action in
         ;;
 
     "wan")
-        notifywanfrom=$(/sbin/e-smith/db configuration getprop root SenderAddress)
         notifyto=$(/sbin/e-smith/db configuration getprop root EmailAddress)
         save_db configuration
-        /sbin/e-smith/db configuration setprop firewall WanMode "$(_get WanMode)" NotifyWan "$(_get NotifyWan)" \
-            MaxNumberPacketLoss "$(_get MaxNumberPacketLoss)" MaxPercentPacketLoss "$(_get MaxPercentPacketLoss)" PingInterval "$(_get PingInterval)" \
-            CheckIP "$(_get_array CheckIP)" NotifyWanTo "$notifyto" NotifyWanFrom "$notifywanfrom"
+        /sbin/e-smith/db configuration setprop firewall WanMode "$(_get WanMode)" MaxNumberPacketLoss "$(_get MaxNumberPacketLoss)" \
+            MaxPercentPacketLoss "$(_get MaxPercentPacketLoss)" PingInterval "$(_get PingInterval)" \
+            CheckIP "$(_get_array CheckIP)"
+        if [[ -n $notifyto ]]; then
+           /sbin/e-smith/db configuration setprop firewall NotifyWan "$(_get NotifyWan)"
+        fi
         ;;
 
     "reorder")

--- a/api/wan/update
+++ b/api/wan/update
@@ -47,14 +47,10 @@ case $action in
         ;;
 
     "wan")
-        notifyto=$(/sbin/e-smith/db configuration getprop root EmailAddress)
         save_db configuration
         /sbin/e-smith/db configuration setprop firewall WanMode "$(_get WanMode)" MaxNumberPacketLoss "$(_get MaxNumberPacketLoss)" \
             MaxPercentPacketLoss "$(_get MaxPercentPacketLoss)" PingInterval "$(_get PingInterval)" \
-            CheckIP "$(_get_array CheckIP)"
-        if [[ -n $notifyto ]]; then
-           /sbin/e-smith/db configuration setprop firewall NotifyWan "$(_get NotifyWan)"
-        fi
+            CheckIP "$(_get_array CheckIP)" NotifyWan "$(_get NotifyWan)"
         ;;
 
     "reorder")

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -160,6 +160,8 @@
         "fireqos_temporary_disabled": "Traffic shaping is temporarily disabled during the speed test.",
         "speedtest_error": "Speedtest failed: please check Internet connection.",
         "click_to_open": "Click to expand details",
+        "email_notifications_is_not_set":"The email for notification is not set",
+        "settings_email_notifications":"Email notifications",
         "current_ip": "Current public IP"
     },
     "traffic_shaping": {

--- a/ui/src/views/WAN.vue
+++ b/ui/src/views/WAN.vue
@@ -535,7 +535,22 @@
                   for="textInput-modal-markup"
                 >{{$t('wan.notify_status_change')}}</label>
                 <div class="col-sm-9">
-                  <input type="checkbox" v-model="wan.NotifyWan" class="form-control" />
+                  <input v-if="wan.EmailAddress" type="checkbox" v-model="wan.NotifyWan" class="form-control" />
+                  <div
+                      v-if="!wan.EmailAddress"
+                      class="alert alert-info"
+                    >
+                      <span class="pficon pficon-info"></span>
+                      {{$t('wan.email_notifications_is_not_set')}}.
+                      <a
+                        target="_blank"
+                        class="pull-right"
+                        href="/nethserver#/settings"
+                      >
+                      {{$t('wan.settings_email_notifications')}}
+                      <span class="fa fa-external-link"></span>
+                      </a>
+                  </div>
                   <small v-if="wan.EmailAddress">{{wan.EmailAddress}}</small>
                   <span v-if="wan.errors.NotifyWan.hasError" class="help-block">
                     {{$t('validation.validation_failed')}}:

--- a/ui/src/views/WAN.vue
+++ b/ui/src/views/WAN.vue
@@ -535,9 +535,9 @@
                   for="textInput-modal-markup"
                 >{{$t('wan.notify_status_change')}}</label>
                 <div class="col-sm-9">
-                  <input v-if="wan.EmailAddress" type="checkbox" v-model="wan.NotifyWan" class="form-control" />
+                  <input v-if="wan.EmailAddress !== 'root@localhost'" type="checkbox" v-model="wan.NotifyWan" class="form-control" />
                   <div
-                      v-if="!wan.EmailAddress"
+                      v-if="wan.EmailAddress === 'root@localhost'"
                       class="alert alert-info"
                     >
                       <span class="pficon pficon-info"></span>
@@ -551,7 +551,7 @@
                       <span class="fa fa-external-link"></span>
                       </a>
                   </div>
-                  <small v-if="wan.EmailAddress">{{wan.EmailAddress}}</small>
+                  <small v-if="wan.EmailAddress && wan.EmailAddress !== 'root@localhost'">{{wan.EmailAddress}}</small>
                   <span v-if="wan.errors.NotifyWan.hasError" class="help-block">
                     {{$t('validation.validation_failed')}}:
                     {{$t('validation.'+wan.errors.NotifyWan.message)}}


### PR DESCRIPTION
When root{EmailAddress} is empty the API use it to overwrite NotifyWanTo with an empty value

Same for NotifyWanFrom

https://github.com/NethServer/dev/issues/6497


![Screenshot - 2021-04-29T180120 911](https://user-images.githubusercontent.com/3164851/116581741-efa5e980-a914-11eb-9ac7-b76d1389cc3f.png)
![Screenshot - 2021-04-29T180036 994](https://user-images.githubusercontent.com/3164851/116581747-f03e8000-a914-11eb-9e21-442cd4a19eaa.png)
