### PR TITLE
Port range, must be ascending numerical order

### DIFF
--- a/api/port-forward/validate
+++ b/api/port-forward/validate
@@ -55,12 +55,6 @@ case "create":
     $protocols = array('tcpudp', 'tcp', 'udp', 'gre', 'ah', 'esp');
     $protoValidator = $v->createValidator()->memberOf($protocols);
 
-    $portRangeValidator = $v->createValidator()
-        ->orValidator(
-            $v->createValidator(Validate::PORTNUMBER),
-            $v->createValidator()->regexp('/^[0-9]+\:[0-9]+$/') #port range, no check on maximum value
-        );
-
     $dstValidator = $v->createValidator()
         ->orValidator(
             $v->createValidator(Validate::PORTNUMBER),
@@ -108,8 +102,17 @@ case "create":
 
     if (is_array($data['Src'])) {
         foreach ($data['Src'] as $el) {
-            if (!$portRangeValidator->evaluate($el)) {
-                $v->addValidationError('Src', 'port_number_or_port_range');
+            if (strpos($el, ":") !== false ) { # port range
+                $tmp = explode(":",$el);
+                # two non-zero integers, right number must be greater then left one
+                if ( !isset($tmp[0], $tmp[1]) || !(int)$tmp[0] || !(int)$tmp[1] || (int)$tmp[0] >= (int)$tmp[1] ) {
+                    $v->addValidationError('Src', 'not_valid_port_range',$el);
+                }
+            } else {
+                $portValidator = $v->createValidator(Validate::PORTNUMBER);
+                if(!$portValidator->evaluate($el)) {
+                    $v->addValidationError('Src', 'not_valid_port_number',$el);
+                }
             }
         }
     } else {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -534,7 +534,7 @@
         "service_exists": "A service with the same name already exists",
         "not_exists_service": "Service does not exist",
         "service_not_removable": "This service can't be removed because it is in use",
-        "not_valid_port_range": "Invalid port range.",
+        "not_valid_port_range": "Invalid port range",
         "not_valid_port_number": "Invalid port number",
         "zone_exists": "A zone with the same name already exists",
         "not_exists_zone": "Zone does not exist",

--- a/ui/src/views/PortForward.vue
+++ b/ui/src/views/PortForward.vue
@@ -246,7 +246,7 @@
                   >{{newPf.SrcType}}</span>
                   <span v-if="newPf.errors.Src.hasError" class="help-block">
                     {{$t('validation.validation_failed')}}:
-                    {{$t('validation.'+newPf.errors.Src.message)}}
+                    {{$t('validation.'+newPf.errors.Src.message)}} : {{newPf.errors.Src.value}}
                   </span>
                 </div>
               </div>
@@ -702,7 +702,8 @@ export default {
         },
         Src: {
           hasError: false,
-          message: ""
+          message: "",
+          value: ""
         },
         DstHost: {
           hasError: false,


### PR DESCRIPTION
If port range are written to /etc/shorewall/rules in decreasing numerical order we have warnings in shorewall restart and we break the event

NethServer/dev#6509

![Screenshot - 2021-05-11T185144 433](https://user-images.githubusercontent.com/3164851/117854656-fd029280-b289-11eb-8730-3dd0279d1336.png)
![Screenshot - 2021-05-11T185120 298](https://user-images.githubusercontent.com/3164851/117854659-fd9b2900-b289-11eb-8760-755c093ce5b6.png)
