### PR TITLE
Use bit instead of byte for speedtest

### DIFF
--- a/ui/src/views/WAN.vue
+++ b/ui/src/views/WAN.vue
@@ -2201,18 +2201,14 @@ export default {
                 '<b class="col-sm-6">' +
                 context.$i18n.t("download") +
                 '</b><span class="col-sm-6">' +
-                ((success.download &&
-                  context.$options.filters.byteFormat(success.download / 8)+'/s') ||
-                  "-") +
+                (! success.download ? "-" : success.download > 1048576 ? (Math.round(success.download / 1048576)+' Mbit/s') : (Math.round(success.download / 1024)+' Kbit/s')) +
                 "</span>";
 
               popover.options.content +=
                 '<b class="col-sm-6">' +
                 context.$i18n.t("upload") +
                 '</b><span class="col-sm-6">' +
-                ((success.upload &&
-                  context.$options.filters.byteFormat(success.upload / 8)+'/s') ||
-                  "-") +
+                (! success.upload ? "-" : success.upload > 1048576 ? (Math.round(success.upload / 1048576)+' Mbit/s') : (Math.round(success.upload / 1024)+' Kbit/s')) +
                 "</span>";
 
               popover.options.content +=


### PR DESCRIPTION
We display the value of speedtest in Megabytes but the international value is the megabit.

If the speedtest is inferior to 1megabit we display the value in kilobits

https://github.com/NethServer/dev/issues/6513


![Screenshot - 2021-05-17T184616 570](https://user-images.githubusercontent.com/3164851/118526720-d2f51880-b740-11eb-87f2-8fd35a0592fb.png)
