### PR TITLE
Display the speedtest-cli in bit format

### DIFF
--- a/ui/src/filters/filters.js
+++ b/ui/src/filters/filters.js
@@ -1,6 +1,36 @@
 import Vue from "vue"
 
 var Filters = {
+    bitFormat: function (size) {
+        var result;
+
+        switch (true) {
+            case size === null || size === "" || isNaN(size):
+                result = "-";
+                break;
+
+            case size >= 0 && size < 1024:
+                result = size + " bit";
+                break;
+
+            case size >= 1024 && size < Math.pow(1024, 2):
+                result = Math.round(size / 1024) + " Kbit";
+                break;
+
+            case size >= Math.pow(1024, 2) && size < Math.pow(1024, 3):
+                result = Math.round(size / Math.pow(1024, 2)) + " Mbit";
+                break;
+
+            case size >= Math.pow(1024, 3) && size < Math.pow(1024, 4):
+                result = Math.round(size / Math.pow(1024, 3)) + " Gbit";
+                break;
+
+            default:
+                result = Math.round(size / Math.pow(1024, 4)) + " Tbit";
+        }
+
+        return result;
+    },
     byteFormat: function (size) {
         var result;
 

--- a/ui/src/filters/filters.js
+++ b/ui/src/filters/filters.js
@@ -10,23 +10,23 @@ var Filters = {
                 break;
 
             case size >= 0 && size < 1024:
-                result = size + " bit";
+                result = Math.round(size) + " bit";
                 break;
 
             case size >= 1024 && size < Math.pow(1024, 2):
-                result = Math.round(size / 1024) + " Kbit";
+                result = Math.round(size / 1024 * 100) / 100 + " Kbit";
                 break;
 
             case size >= Math.pow(1024, 2) && size < Math.pow(1024, 3):
-                result = Math.round(size / Math.pow(1024, 2)) + " Mbit";
+                result = Math.round(size / Math.pow(1024, 2) * 100) / 100 + " Mbit";
                 break;
 
             case size >= Math.pow(1024, 3) && size < Math.pow(1024, 4):
-                result = Math.round(size / Math.pow(1024, 3)) + " Gbit";
+                result = Math.round(size / Math.pow(1024, 3) * 100) / 100 + " Gbit";
                 break;
 
             default:
-                result = Math.round(size / Math.pow(1024, 4)) + " Tbit";
+                result = Math.round(size / Math.pow(1024, 4) * 100) / 100 + " Tbit";
         }
 
         return result;

--- a/ui/src/views/WAN.vue
+++ b/ui/src/views/WAN.vue
@@ -2202,7 +2202,7 @@ export default {
                 context.$i18n.t("download") +
                 '</b><span class="col-sm-6">' +
                 ((success.download &&
-                  context.$options.filters.byteFormat(success.download / 8)+'/s') ||
+                  context.$options.filters.bitFormat(success.download)+'/s') ||
                   "-") +
                 "</span>";
 
@@ -2211,7 +2211,7 @@ export default {
                 context.$i18n.t("upload") +
                 '</b><span class="col-sm-6">' +
                 ((success.upload &&
-                  context.$options.filters.byteFormat(success.upload / 8)+'/s') ||
+                  context.$options.filters.bitFormat(success.upload)+'/s') ||
                   "-") +
                 "</span>";
 


### PR DESCRIPTION
We display the value of speedtest in Megabytes but the international value is the megabit.

If the speedtest is inferior to 1megabit we display the value in kilobits

https://github.com/NethServer/dev/issues/6513


![Screenshot - 2021-05-17T184616 570](https://user-images.githubusercontent.com/3164851/118526720-d2f51880-b740-11eb-87f2-8fd35a0592fb.png)