### PR TITLE
No update banner for the settings panel

### DIFF
--- a/api/settings/update
+++ b/api/settings/update
@@ -25,7 +25,6 @@
 case $action in
 
     "settings")
-        save_db configuration
         /sbin/e-smith/db configuration setprop firewall ExternalPing "$(_get ExternalPing)" Policy "$(_get Policy)" HairpinNat "$(_get HairpinNat)" \
             MACValidationPolicy "$(_get MACValidationPolicy)" MACValidation "$(_get MACValidation)" VpnPolicy "$(_get VpnPolicy)" SipAlg "$(_get SipAlg)"
         /sbin/e-smith/signal-event -j firewall-adjust


### PR DESCRIPTION
Inside the settings page, once the settings are saved the banner to apply the change appears but it is not needed at all.

The simple fix is to remove the banner for that particular page.

https://github.com/NethServer/dev/issues/6519