### PR TITLE
PPPoE: always restart shorewall on interface up

### DIFF
--- a/root/etc/ppp/ip-up.ppp0
+++ b/root/etc/ppp/ip-up.ppp0
@@ -36,7 +36,7 @@
 . /etc/sysconfig/network-scripts/ifcfg-ppp0
 if [ "${DEFROUTE}" = "no" ]; then
   /usr/sbin/shorewall enable ppp0  &>/dev/null
-  /usr/sbin/shorewall restart &>/dev/null
 fi
+/usr/sbin/shorewall restart &>/dev/null
 
 


### PR DESCRIPTION
If PPPoE has a dynamic IP, the restart will create port
forward rules using the new IP address.

NethServer/dev#6568