### PR TITLE
ui. fix never-ending spinners in Services tab

### DIFF
--- a/ui/src/components/TroubleshootingHosts.vue
+++ b/ui/src/components/TroubleshootingHosts.vue
@@ -474,8 +474,11 @@ export default {
               chart.data[t][0] = new Date(chart.data[t][0]);
             }
 
-            const i18nLabels = chart.labels.map((label) =>
-              context.$i18n.t("troubleshooting." + label)
+            const i18nLabels = chart.labels.map(
+              (label) =>
+                context.$i18n
+                  ? context.$i18n.t("troubleshooting." + label)
+                  : label
             );
 
             var g = new Dygraph(
@@ -488,7 +491,9 @@ export default {
                 height: 300,
                 strokeWidth: 1,
                 strokeBorderWidth: 1,
-                ylabel: context.$i18n.t("troubleshooting.traffic_mbps"),
+                ylabel: context.$i18n
+                  ? context.$i18n.t("troubleshooting.traffic_mbps")
+                  : "",
                 labelsDiv: document.getElementById("host-traffic-legend"),
                 axisLineColor: "white",
                 labelsSeparateLines: true,

--- a/ui/src/components/TroubleshootingNetwork.vue
+++ b/ui/src/components/TroubleshootingNetwork.vue
@@ -462,7 +462,9 @@ export default {
                 chart.data[t][0] = new Date(chart.data[t][0]);
               }
               const i18nLabels = chart.labels.map((label) =>
-                context.$i18n.t("troubleshooting." + label)
+                context.$i18n
+                  ? context.$i18n.t("troubleshooting." + label)
+                  : label
               );
               context.isLoaded.ifacePingCharts = true;
 
@@ -477,7 +479,9 @@ export default {
                     height: 200,
                     strokeWidth: 1,
                     strokeBorderWidth: 1,
-                    ylabel: context.$i18n.t("troubleshooting.latency_ms"),
+                    ylabel: context.$i18n
+                      ? context.$i18n.t("troubleshooting.latency_ms")
+                      : "",
                     axisLineColor: "white",
                     labelsDiv: document.getElementById(
                       `ping-legend-${redName}-${ip}`
@@ -527,7 +531,9 @@ export default {
               }
 
               const i18nLabels = chart.labels.map((label) =>
-                context.$i18n.t("troubleshooting." + label)
+                context.$i18n
+                  ? context.$i18n.t("troubleshooting." + label)
+                  : label
               );
 
               var g = new Dygraph(
@@ -540,7 +546,9 @@ export default {
                   height: 200,
                   strokeWidth: 1,
                   strokeBorderWidth: 1,
-                  ylabel: context.$i18n.t("troubleshooting.traffic_mbps"),
+                  ylabel: context.$i18n
+                    ? context.$i18n.t("troubleshooting.traffic_mbps")
+                    : "",
                   axisLineColor: "white",
                   labelsDiv: document.getElementById(
                     "traffic-legend-" + iface.name
@@ -588,7 +596,9 @@ export default {
               }
 
               const i18nLabels = chart.labels.map((label) =>
-                context.$i18n.t("troubleshooting." + label)
+                context.$i18n
+                  ? context.$i18n.t("troubleshooting." + label)
+                  : label
               );
 
               var g = new Dygraph(
@@ -601,7 +611,9 @@ export default {
                   height: 200,
                   strokeWidth: 1,
                   strokeBorderWidth: 1,
-                  ylabel: context.$i18n.t("troubleshooting.latency_ms"),
+                  ylabel: context.$i18n
+                    ? context.$i18n.t("troubleshooting.latency_ms")
+                    : "",
                   axisLineColor: "white",
                   labelsDiv: document.getElementById("ping-legend-" + ip),
                   labelsSeparateLines: true,
@@ -648,7 +660,9 @@ export default {
               }
 
               const i18nLabels = chart.labels.map((label) =>
-                context.$i18n.t("troubleshooting." + label)
+                context.$i18n
+                  ? context.$i18n.t("troubleshooting." + label)
+                  : label
               );
 
               var g = new Dygraph(
@@ -661,7 +675,9 @@ export default {
                   height: 200,
                   strokeWidth: 1,
                   strokeBorderWidth: 1,
-                  ylabel: context.$i18n.t("troubleshooting.droprate_perc"),
+                  ylabel: context.$i18n
+                    ? context.$i18n.t("troubleshooting.droprate_perc")
+                    : "",
                   axisLineColor: "white",
                   labelsDiv: document.getElementById(
                     "ping-droprate-legend-" + ip

--- a/ui/src/components/TroubleshootingServices.vue
+++ b/ui/src/components/TroubleshootingServices.vue
@@ -1131,7 +1131,6 @@ export default {
         },
         function(error) {
           console.error(error);
-          context["view"][service]["isLoaded"] = false;
         }
       );
     },

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -569,14 +569,17 @@ export default {
     },
     initGraph() {
       var container = document.getElementById("network-graph");
-      var network = new vis.Network(
-        container,
-        {
-          nodes: this.nodes,
-          edges: this.edges
-        },
-        this.options
-      );
+
+      if(container) {
+        var network = new vis.Network(
+          container,
+          {
+            nodes: this.nodes,
+            edges: this.edges
+          },
+          this.options
+        );
+      }
     },
     getInterfaces(callback) {
       var context = this;
@@ -599,7 +602,7 @@ export default {
             if (success.configuration[role].length > 0)
               context.nodes.push({
                 id: role,
-                label: context.$i18n.t("dashboard." + role),
+                label: context && context.$i18n && context.$i18n.t("dashboard." + role) || '',
                 group: role,
                 level: context.levelMap(role, true)
               });


### PR DESCRIPTION
A bug hard to reproduce shows never-ending spinners in Services tab.
It looks like it is caused by a race condition in Vue context management.

https://github.com/NethServer/dev/issues/6582