### PR TITLE
wan API: skip invalid charts

### DIFF
--- a/api/wan/read
+++ b/api/wan/read
@@ -126,12 +126,9 @@ if($cmd eq 'providers') {
 
     my $ndb = esmith::NetworksDB->open_ro();
     foreach ($ndb->red()) {
-        $ret->{$_->key} = undef;
         my $txt = read_netdata("/api/v1/data?chart=net.".$_->key."&format=csv&before=-1&after=1&options=abs");
-        if ($txt =~ m/Chart is not found/) {
-            delete($ret->{$_->key});
-            next;
-        }
+        next if ($txt =~ m/Chart is not found/);
+        $ret->{$_->key} = undef;
         if ($txt) {
             my @lines = split("\r\n",$txt);
             my @values = split(",",$lines[1]);


### PR DESCRIPTION
If an interface link is down, netdata could return an error like
'Chart is not found: net.ethx'.
Such error creates a JSON with an empty chart for the given interface,
the invalid chart breaks all charts inside the UI.
This commit just avoids to return the chart if it is not available.