### PR TITLE
analysis api. fix wan and ping rrd charts

### DIFF
--- a/api/troubleshooting/read
+++ b/api/troubleshooting/read
@@ -81,7 +81,7 @@ sub fetch_ping_rrd {
     if (! -f $path) {
         return @ret;
     }
-    open(FH, "rrdtool fetch $path AVERAGE -s e-$time|");
+    open(FH, "LANG=C rrdtool fetch $path AVERAGE -s e-$time|");
     while (<FH>) {
     chomp;
     my @lines = split("\r\n");
@@ -145,7 +145,7 @@ sub fetch_wan_rrd {
     if (! -f $path) {
         return @ret;
     }
-    open(FH, "rrdtool fetch $path AVERAGE -s e-$time|");
+    open(FH, "LANG=C rrdtool fetch $path AVERAGE -s e-$time|");
     while (<FH>) {
     chomp;
     my @lines = split("\r\n");


### PR DESCRIPTION
If Cockpit language does not use dot as a decimal separator, then rrd data was wrong

https://github.com/NethServer/dev/issues/6590