### PR TITLE
Always restore connmark

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/20ndpi
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/20ndpi
@@ -14,12 +14,4 @@
    $OUT .= "INLINE():F - - ; -m ndpi --all\n";
    $OUT .= "INLINE \$FW - ; -m ndpi --all\n";
    $OUT .= "IPTABLES(NDPI --ndpi-id-p --set-mark):T\n";
-
-   $OUT .= "# Restore the connection mark into the current packet.\n";
-   $OUT .= "RESTORE:F       -               -               -\n";
-   $OUT .= "# Restore the connection mark for packets from/to firewall (Squid).\n";
-   $OUT .= "# This is useful only for QoS\n";
-   $OUT .= "RESTORE        \$FW             -               - - - - 0x00\n";
-   $OUT .= "RESTORE        -                \$FW            - - - - 0x00\n";
-
 }

--- a/root/etc/e-smith/templates/etc/shorewall/mangle/22restore_connmark
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/22restore_connmark
@@ -1,0 +1,12 @@
+#
+# 22restore_connmark
+#
+{
+   $OUT .= "# Restore the connection mark into the current packet.\n";
+   $OUT .= "RESTORE:F       -               -               -\n";
+   $OUT .= "# Restore the connection mark for packets from/to firewall.\n";
+   $OUT .= "# Used QoS, IPS and Squid\n";
+   $OUT .= "RESTORE        \$FW             -               - - - - 0x00\n";
+   $OUT .= "RESTORE        -                \$FW            - - - - 0x00\n";
+
+}


### PR DESCRIPTION
CONNMARK is also used by the IPS, Squid and QoS, not only by nDPI.