### PR TITLE
troubleshooting api: avoid warning

### DIFF
--- a/api/troubleshooting/read
+++ b/api/troubleshooting/read
@@ -119,7 +119,7 @@ sub fetch_interface_rrd {
         foreach my $line (@lines) {
             my ($time, $octets) = split(":", $line);
             # skip invalid data
-            next unless length $octets > 0;
+            next unless ($octets && $octets =~ m/\d/ && length $octets > 0);
             my ($rcvd, $sent) = split(" ", $octets);
             next unless ($time =~ m/\d/ && $rcvd =~ m/\d/ && $sent =~ m/\d/);
             # make sure to output a numeric value


### PR DESCRIPTION
When collects returtns `nan`, prevent errors like:
  Use of uninitialized value $octets in numeric gt (>) at /usr/libexec/nethserver/api/nethserver-firewall-base/troubleshooting/read line 122, <FH> line 1.