### PR TITLE
Fix the exclusion for separator type in local-rules

### DIFF
--- a/api/lib/firewall_functions.pl
+++ b/api/lib/firewall_functions.pl
@@ -328,12 +328,15 @@ sub list_fw_rules
         $max_posRule = max($max_posRule, $props{'Position'});
         push(@rules, \%props);
     }
-    foreach ($fw->getSeparators()) {
-        my %props = $_->props;
-        $props{'id'} = $_->key;
-        $props{'Position'} = int($props{'Position'});
-        $max_posSeparator = max($max_posSeparator, $props{'Position'});
-        push(@rules, \%props);
+    # separator are only for rules
+    if ($skip_local && @rules) {
+        foreach ($fw->getSeparators()) {
+            my %props = $_->props;
+            $props{'id'} = $_->key;
+            $props{'Position'} = int($props{'Position'});
+            $max_posSeparator = max($max_posSeparator, $props{'Position'});
+            push(@rules, \%props);
+        }
     }
     $next = int(`/usr/libexec/nethserver/api/nethserver-firewall-base/lib/rules-next-id`);
 

--- a/ui/src/views/LocalRules.vue
+++ b/ui/src/views/LocalRules.vue
@@ -65,6 +65,7 @@
           v-for="(r,k) in filteredRules"
           v-bind:key="k"
         >
+          <template v-if="r.type === 'rule'">
           <div class="drag-size">
             <span class="gray mg-right-5">{{r.id}}</span>
           </div>
@@ -214,6 +215,7 @@
               </div>
             </div>
           </div>
+          </template>
         </li>
       </ul>
     </div>

--- a/ui/src/views/Rules.vue
+++ b/ui/src/views/Rules.vue
@@ -61,13 +61,14 @@
           v-for="(r,k) in filteredRules"
           v-bind:key="k"
         >
-          <div v-if="r.type === 'rule'" class="drag-size">
+          <template v-if="r.type === 'rule'">
+          <div class="drag-size">
             <span class="gray mg-right-5">{{r.id}}</span>
           </div>
-          <div v-if="r.type === 'rule'" v-show="searchString.length == 0" class="list-view-pf-checkbox drag-here">
+          <div v-show="searchString.length == 0" class="list-view-pf-checkbox drag-here">
             <span class="fa fa-bars"></span>
           </div>
-          <div v-if="r.type === 'rule'" class="list-view-pf-actions">
+          <div class="list-view-pf-actions">
             <button
               @click="r.status == 'disabled' ? toggleEnableRule(r) : openEditRule(r, false)"
               :class="['btn btn-default', r.status == 'disabled' ? 'btn-primary' : '']"
@@ -113,7 +114,7 @@
               </ul>
             </div>
           </div>
-          <div v-if="r.type === 'rule'" class="list-view-pf-main-info small-list">
+          <div class="list-view-pf-main-info small-list">
             <div class="list-view-pf-left">
               <span
                 data-toggle="tooltip"
@@ -220,10 +221,12 @@
               </div>
             </div>
           </div>
-          <div v-if="r.type === 'separator'" v-show="searchString.length == 0" class="list-view-pf-checkbox drag-here">
+          </template>
+          <template v-if="r.type === 'separator'">
+          <div v-show="searchString.length == 0" class="list-view-pf-checkbox drag-here">
             <span class="fa fa-bars"></span>
           </div>
-          <div v-if="r.type === 'separator'" class="list-view-pf-actions">
+          <div class="list-view-pf-actions">
             <div class="dropup pull-right dropdown-kebab-pf">
               <button
                 class="btn btn-link dropdown-toggle"
@@ -251,7 +254,7 @@
               </ul>
             </div>
           </div>
-          <div v-if="r.type === 'separator'" class="list-view-pf-main-info small-list">
+          <div class="list-view-pf-main-info small-list">
             <div class="list-view-pf-left">
             </div>
             <div class="list-view-pf-body">
@@ -266,6 +269,7 @@
               </div>
             </div>
           </div>
+          </template>
         </li>
       </ul>
     </div>

--- a/ui/src/views/Rules.vue
+++ b/ui/src/views/Rules.vue
@@ -2423,7 +2423,7 @@ export default {
   background-color: #92d400;
 }
 .red-background {
-  background-color: #8b0000;
+  background-color: #cc0000c0;
 }
 .info-desc-local {
   min-width: 75px;


### PR DESCRIPTION
With separator we have had a blank page in the local-rule web page when a separator exists, this PR  fix it, but also

- red color of separator
- exception in the api when we list rules for the local-rules else the object rules is not empty and the default button `create your first local-rule` is not displayed
- exception in the api when we have no rules to not display the separator and display the default button `create your first rule`

NethServer/dev#6602