### PR TITLE
ui: fix traffic shaping chart label

### DIFF
--- a/ui/src/views/TrafficShaping.vue
+++ b/ui/src/views/TrafficShaping.vue
@@ -1998,8 +1998,8 @@ export default {
                     axes: {
                       y: {
                         axisLabelFormatter: function(y) {
-                          // netdata values are expressed in KB
-                          return context.$options.filters.byteFormat(y * 1024);
+                          // netdata values are expressed in Kb
+                          return context.$options.filters.bitFormat(y * 1024);
                         }
                       }
                     }
@@ -2037,8 +2037,8 @@ export default {
                     axes: {
                       y: {
                         axisLabelFormatter: function(y) {
-                          // netdata values are expressed in KB
-                          return context.$options.filters.byteFormat(y * 1024);
+                          // netdata values are expressed in Kb
+                          return context.$options.filters.bitFormat(y * 1024);
                         }
                       }
                     }


### PR DESCRIPTION
The bandwidth should always be displayed in bits and not bytes.

NethServer/dev#6623

See https://community.nethserver.org/t/nethserver-release-7-9-2009-problem-with-upload/19275/17?u=giacomo