### PR TITLE
Exclude IPS bypass bit (0x20) from mark saving

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/80qos_ndpi
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/80qos_ndpi
@@ -1,3 +1,3 @@
 # 80qos_ndpi
-# save packet mark to connections mark
-SAVE:T       -                 -               -     -       -       -       !0x00/0xffff
+# save packet mark to connections mark, excluding IPS bypass mark 0x20
+SAVE(0xffdf):T       -                 -               -     -       -       -       !0x00/0xffff


### PR DESCRIPTION
Due to how packets are processed, the bypass marker could be "lost".
This patch avoids saving the bypass bit on every packet to the
connection mark. The connection will be marked only once in
shorewall-rules, on exit from suricata.

NethServer/dev#6661