### PR TITLE
Move suricata marks outside of QoS range

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/40priorities
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/40priorities
@@ -24,7 +24,7 @@
         if ($action =~ /^class;(.*)/) {
             my $class = $tdb->get($1);
             my $mark = $class->prop('Mark') || next;
-            $mask = "0x$mark/0xff";
+            $mask = "0x$mark/0x3f";
         } else {
             # skip non-priority rules
             next;

--- a/root/etc/e-smith/templates/etc/shorewall/mangle/80qos_ndpi
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/80qos_ndpi
@@ -1,3 +1,3 @@
 # 80qos_ndpi
-# save packet mark to connections mark, excluding IPS bypass mark 0x20
-SAVE(0xffdf):T       -                 -               -     -       -       -       !0x00/0xffff
+# save packet mark to connections mark, excluding IPS bypass mark 0x80
+SAVE(0xff7f):T       -                 -               -     -       -       -       !0x00/0xffff


### PR DESCRIPTION
    As QoS supports a maximum of 63 marks, to avoid clashes with suricata,
    move the bypass mark to the highest bit (!0x80=0x7f).

NethServer/dev#6690